### PR TITLE
Fix for building python bindings for the first time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ else
 fi
 if [test "x$CYTHON" != "xfalse"]; then
             AC_MSG_CHECKING([for libplist Cython bindings])
-            CYTHON_PLIST_INCLUDE_DIR=$($PKG_CONFIG --variable=includedir libplist)/plist/cython
+            CYTHON_PLIST_INCLUDE_DIR=.
             if [test ! -d "$CYTHON_PLIST_INCLUDE_DIR"]; then
                 CYTHON=false
                 CYTHON_SUB=


### PR DESCRIPTION
This patch makes happy the autoconf location of CYTHON_PLIST_INCLUDE_DIR so that it will build python bindings even when no prior version of libplist is found by pkg-config.
