### PR TITLE
plist_set_type: fix non functional code (found by leak analyzis)

### DIFF
--- a/src/plist.c
+++ b/src/plist.c
@@ -764,6 +764,7 @@ void plist_set_type(plist_t node, plist_type type)
         plist_data_t data = plist_get_data(node);
         plist_free_data( data );
         data = plist_new_plist_data();
+        ((node_t*)node)->data = data;
         data->type = type;
         switch (type)
         {


### PR DESCRIPTION
Looks like plist_set_type() never set the type. Worse, it leave the node data to a deallocated pointer value.
