### PR TITLE
added missing include, removed double-frees in Array.cpp

### DIFF
--- a/include/plist/Node.h
+++ b/include/plist/Node.h
@@ -23,6 +23,7 @@
 #define PLIST_NODE_H
 
 #include <plist/plist.h>
+#include <cstddef>
 
 namespace PList
 {

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -124,7 +124,6 @@ void Array::Remove(Node* node)
     if (node)
     {
         uint32_t pos = plist_array_get_item_index(node->GetPlist());
-        plist_array_remove_item(_node, pos);
         std::vector<Node*>::iterator it = _array.begin();
         it += pos;
         _array.erase(it);
@@ -134,7 +133,6 @@ void Array::Remove(Node* node)
 
 void Array::Remove(unsigned int pos)
 {
-    plist_array_remove_item(_node, pos);
     std::vector<Node*>::iterator it = _array.begin();
     it += pos;
     delete _array.at(pos);


### PR DESCRIPTION
Two bugs existed when I freshly cloned the repository: a missing #include kept the library from compiling and a redundant plist_free() call caused the library to segfault when calling the Remove member of PList::Array.

The Remove member calls plist_array_remove_item() which amounts to a call to plist_free() and that is called from the PList::Node destructor. After the first call, _node->children will be null, and during the second call node_iterator_create() will try to dereference it.

Testing code: https://gist.github.com/hattmammerly/a9b05f71020416b7b828
Compile error without `#include <cstddef>` added in Node.h: https://gist.github.com/hattmammerly/6dcf5347dfdb7fd99c3d
Backtrace of segfault occurring when calling PList::Array::Remove: https://gist.github.com/hattmammerly/95e2cb70761be4493327

Please feel free to contact me with questions.

Thanks!
