### PR TITLE
Allow to run autogen.sh outside $top_srcdir

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,15 +1,22 @@
 #!/bin/sh
-gprefix=`which glibtoolize 2>&1 >/dev/null`
-if [ $? -eq 0 ]; then 
-  glibtoolize --force
-else
-  libtoolize --force
-fi
-aclocal -I m4
-autoheader
-automake --add-missing
-autoconf
+
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(
+    cd "$srcdir"
+    gprefix=`which glibtoolize 2>&1 >/dev/null`
+    if [ $? -eq 0 ]; then
+      glibtoolize --force
+    else
+      libtoolize --force
+    fi
+    aclocal -I m4
+    autoheader
+    automake --add-missing
+    autoconf
+)
 
 if [ -z "$NOCONFIGURE" ]; then
-    ./configure "$@"
+    "$srcdir/configure" "$@"
 fi


### PR DESCRIPTION
This makes it more convenient to do builds out of the source dir.