### PR TITLE
fix python module build with libplist already installed

### DIFF
--- a/cython/Makefile.am
+++ b/cython/Makefile.am
@@ -20,7 +20,7 @@ plistdir = $(pyexecdir)
 plist_LTLIBRARIES = plist.la
 plist_la_SOURCES = plist_util.c plist_util.h plist.pyx
 plist_la_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src $(PYTHON_CPPFLAGS) $(AM_CFLAGS) -Wno-shadow -Wno-redundant-decls -Wno-switch-default -Wno-strict-aliasing -Wno-implicit-function-declaration -fvisibility=default
-plist_la_LDFLAGS = -module -avoid-version -L$(libdir) $(PYTHON_LDFLAGS) $(AM_LDFLAGS)
+plist_la_LDFLAGS = -module -avoid-version $(PYTHON_LDFLAGS) $(AM_LDFLAGS)
 plist_la_LIBADD = $(top_builddir)/src/libplist.la
 
 plist.c: plist.pyx $(PXDINCLUDES) $(PXIINCLUDES)


### PR DESCRIPTION
problem:
when i have libplist-devel installed when building new libplist version
the python build will link against libplist from system (/usr/lib), not the one i'm currently building.

this results python linking with old SONAME

taken from:
https://github.com/pld-linux/libplist/commit/a4a4e4b04caef3f9875b598d64ffb1fb388e699e