### PR TITLE
Move libxml cleanup code to a plist_cleanup method

### DIFF
--- a/include/plist/plist.h
+++ b/include/plist/plist.h
@@ -113,6 +113,19 @@ extern "C"
 
     /********************************************
      *                                          *
+     *     Library Initialization & Cleanup     *
+     *                                          *
+     ********************************************/
+
+    /**
+     * Frees memory used globally by listplist, in
+     * particular the libxml parser
+     */
+    
+    void plist_cleanup(void);
+    
+    /********************************************
+     *                                          *
      *          Creation & Destruction          *
      *                                          *
      ********************************************/

--- a/src/plist.c
+++ b/src/plist.c
@@ -31,6 +31,24 @@
 #include <node.h>
 #include <node_iterator.h>
 
+#include <libxml/encoding.h>
+#include <libxml/dict.h>
+#include <libxml/xmlerror.h>
+#include <libxml/globals.h>
+#include <libxml/threads.h>
+#include <libxml/xmlmemory.h>
+
+void plist_cleanup(void)
+{
+    /* free memory from parser initialization */
+    xmlCleanupCharEncodingHandlers();
+    xmlDictCleanup();
+    xmlResetLastError();
+    xmlCleanupGlobals();
+    xmlCleanupThreads();
+    xmlCleanupMemory();
+}
+
 plist_t plist_new_node(plist_data_t data)
 {
     return (plist_t) node_create(NULL, data);

--- a/src/xplist.c
+++ b/src/xplist.c
@@ -573,15 +573,6 @@ PLIST_API void plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length)
 	tmp = NULL;
     }
     xmlFreeDoc(plist_doc);
-
-
-    /* free memory from parser initialization */
-    xmlCleanupCharEncodingHandlers();
-    xmlDictCleanup();
-    xmlResetLastError();
-    xmlCleanupGlobals();
-    xmlCleanupThreads();
-    xmlCleanupMemory();
 }
 
 static xmlParserInputPtr plist_xml_external_entity_loader(const char *URL, const char *ID, xmlParserCtxtPtr ctxt)
@@ -602,12 +593,4 @@ PLIST_API void plist_from_xml(const char *plist_xml, uint32_t length, plist_t * 
         xml_to_node(root_node, plist);
         xmlFreeDoc(plist_doc);
     }
-
-    /* free memory from parser initialization */
-    xmlCleanupCharEncodingHandlers();
-    xmlDictCleanup();
-    xmlResetLastError();
-    xmlCleanupGlobals();
-    xmlCleanupThreads();
-    xmlCleanupMemory();
 }


### PR DESCRIPTION
In spirit of #57 and #68 and the comments made by @FunkyM, @nikias, @cfergeau and @progressnerd, this PR attempts to move the libxml cleanup code introduced by a11e8b1b9a76 to a seperate `plist_cleanup` method. It would be the responsability of the user of libplist to actually call this method if required.

Feedback is welcome; I think this multithreading issue is causing quite some of the crashes in libimobiledevice so it would be good to have this addressed.