### PR TITLE
Add plist_to_bin_free and plist_to_xml_free methods

### DIFF
--- a/include/plist/plist.h
+++ b/include/plist/plist.h
@@ -576,6 +576,13 @@ extern "C"
     void plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length);
 
     /**
+    * Frees the memory allocated by plist_to_xml
+    *
+    * @param plist_bin The object allocated by plist_to_xml
+    */
+    void plist_to_xml_free(char **plist_xml);
+
+    /**
      * Export the #plist_t structure to binary format.
      *
      * @param plist the root node to export
@@ -584,6 +591,13 @@ extern "C"
      * @param length a pointer to an uint32_t variable. Represents the length of the allocated buffer.
      */
     void plist_to_bin(plist_t plist, char **plist_bin, uint32_t * length);
+
+    /**
+      * Frees the memory allocated by plist_to_bin
+      *
+      * @param plist_bin The object allocated by plist_to_bin
+      */
+    void plist_to_bin_free(char **plist_bin);
 
     /**
      * Import the #plist_t structure from XML format.

--- a/include/plist/plist.h
+++ b/include/plist/plist.h
@@ -578,7 +578,7 @@ extern "C"
     /**
     * Frees the memory allocated by plist_to_xml
     *
-    * @param plist_bin The object allocated by plist_to_xml
+    * @param plist_xml The object allocated by plist_to_xml
     */
     void plist_to_xml_free(char **plist_xml);
 

--- a/src/bplist.c
+++ b/src/bplist.c
@@ -1236,3 +1236,8 @@ PLIST_API void plist_to_bin(plist_t plist, char **plist_bin, uint32_t * length)
     byte_array_free(bplist_buff);
     free(offsets);
 }
+
+PLIST_API void plist_to_bin_free(char **plist_bin)
+{
+    free(plist_bin);
+}

--- a/src/xplist.c.orig
+++ b/src/xplist.c.orig
@@ -21,6 +21,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifdef _MSC_VER
+#include "msc_config.h"
+#endif
 
 #include <string.h>
 #include <assert.h>
@@ -388,7 +391,7 @@ static void xml_to_node(xmlNodePtr xml_node, plist_t * plist_node)
         data = plist_new_plist_data();
         subnode = plist_new_node(data);
         if (*plist_node)
-            node_attach(*plist_node, subnode);
+			node_attach((node_t*)*plist_node, (node_t*)subnode);
         else
             *plist_node = subnode;
 
@@ -559,7 +562,19 @@ PLIST_API void plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length)
     root_node = xmlDocGetRootElement(plist_doc);
     root.xml = root_node;
 
+<<<<<<< HEAD
+    char *current_locale = setlocale(LC_NUMERIC, NULL);
+    char *saved_locale = NULL;
+    if (current_locale) {
+        saved_locale = strdup(current_locale);
+    }
+    if (saved_locale) {
+        setlocale(LC_NUMERIC, "POSIX");
+    }
+	node_to_xml((node_t*)plist, &root);
+=======
     node_to_xml(plist, &root);
+>>>>>>> master-upstream
 
     xmlChar* tmp = NULL;
     xmlDocDumpMemory(plist_doc, &tmp, &size);
@@ -582,11 +597,6 @@ PLIST_API void plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length)
     xmlCleanupGlobals();
     xmlCleanupThreads();
     xmlCleanupMemory();
-}
-
-PLIST_API void plist_to_xml_free(char **plist_xml)
-{
-    free(plist_xml);
 }
 
 static xmlParserInputPtr plist_xml_external_entity_loader(const char *URL, const char *ID, xmlParserCtxtPtr ctxt)


### PR DESCRIPTION
`plist_to_xml` and `plist_to_bin` allocate memory, but the libplist API does not expose any methods that can free that memory.

That's fine if you're calling these libraries from C - just call `free`. However, if you're calling from a .NET environment, there's no `free` and you need a function that you can call to free the memory.

This PR adds the `plist_to_xml_free` and `plist_to_bin_free` methods which do just that.
