### PR TITLE
Add Visual C++ support (rebased)

### DIFF
--- a/include/plist/Date.h
+++ b/include/plist/Date.h
@@ -24,7 +24,11 @@
 
 #include <plist/Node.h>
 #include <ctime>
+#ifdef _MSC_VER
+#include <winsock2.h>
+#else
 #include <sys/time.h>
+#endif
 
 namespace PList
 {

--- a/include/plist/Dictionary.h
+++ b/include/plist/Dictionary.h
@@ -48,7 +48,7 @@ public :
     iterator Find(const std::string& key);
     iterator Set(const std::string& key, const Node* node);
     iterator Set(const std::string& key, const Node& node);
-    iterator Insert(const std::string& key, Node* node) PLIST_WARN_DEPRECATED("use Set() instead");
+    PLIST_WARN_DEPRECATED("use Set() instead") iterator Insert(const std::string& key, Node* node);
     void Remove(Node* node);
     void Remove(const std::string& key);
     std::string GetNodeKey(Node* key);

--- a/include/plist/plist.h
+++ b/include/plist/plist.h
@@ -29,7 +29,6 @@ extern "C"
 #endif
 
 #ifdef _MSC_VER
-    typedef __int8 int8_t;
     typedef __int16 int16_t;
     typedef __int32 int32_t;
     typedef __int64 int64_t;

--- a/include/plist/plist.h
+++ b/include/plist/plist.h
@@ -42,6 +42,12 @@ extern "C"
 #include <stdint.h>
 #endif
 
+#ifdef _MSC_VER 
+#define PLIST_API_MSC __declspec( dllexport ) 
+#else  
+#define PLIST_API_MSC 
+#endif 
+
 #ifdef __llvm__
   #if defined(__has_extension)
     #if (__has_extension(attribute_deprecated_with_message))
@@ -135,7 +141,7 @@ extern "C"
      * @return the created plist
      * @sa #plist_type
      */
-    plist_t plist_new_dict(void);
+    PLIST_API_MSC plist_t plist_new_dict(void);
 
     /**
      * Create a new root plist_t type #PLIST_ARRAY
@@ -143,7 +149,7 @@ extern "C"
      * @return the created plist
      * @sa #plist_type
      */
-    plist_t plist_new_array(void);
+    PLIST_API_MSC plist_t plist_new_array(void);
 
     /**
      * Create a new plist_t type #PLIST_STRING
@@ -152,7 +158,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_string(const char *val);
+    PLIST_API_MSC plist_t plist_new_string(const char *val);
 
     /**
      * Create a new plist_t type #PLIST_BOOLEAN
@@ -161,7 +167,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_bool(uint8_t val);
+    PLIST_API_MSC plist_t plist_new_bool(uint8_t val);
 
     /**
      * Create a new plist_t type #PLIST_UINT
@@ -170,7 +176,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_uint(uint64_t val);
+    PLIST_API_MSC plist_t plist_new_uint(uint64_t val);
 
     /**
      * Create a new plist_t type #PLIST_REAL
@@ -179,7 +185,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_real(double val);
+    PLIST_API_MSC plist_t plist_new_real(double val);
 
     /**
      * Create a new plist_t type #PLIST_DATA
@@ -189,7 +195,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_data(const char *val, uint64_t length);
+    PLIST_API_MSC plist_t plist_new_data(const char *val, uint64_t length);
 
     /**
      * Create a new plist_t type #PLIST_DATE
@@ -199,7 +205,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_date(int32_t sec, int32_t usec);
+    PLIST_API_MSC plist_t plist_new_date(int32_t sec, int32_t usec);
 
     /**
      * Create a new plist_t type #PLIST_UID
@@ -208,14 +214,14 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_uid(uint64_t val);
+    PLIST_API_MSC plist_t plist_new_uid(uint64_t val);
 
     /**
      * Destruct a plist_t node and all its children recursively
      *
      * @param plist the plist to free
      */
-    void plist_free(plist_t plist);
+    PLIST_API_MSC void plist_free(plist_t plist);
 
     /**
      * Return a copy of passed node and it's children
@@ -223,7 +229,7 @@ extern "C"
      * @param node the plist to copy
      * @return copied plist
      */
-    plist_t plist_copy(plist_t node);
+    PLIST_API_MSC plist_t plist_copy(plist_t node);
 
 
     /********************************************
@@ -238,7 +244,7 @@ extern "C"
      * @param node the node of type #PLIST_ARRAY
      * @return size of the #PLIST_ARRAY node
      */
-    uint32_t plist_array_get_size(plist_t node);
+    PLIST_API_MSC uint32_t plist_array_get_size(plist_t node);
 
     /**
      * Get the nth item in a #PLIST_ARRAY node.
@@ -247,7 +253,7 @@ extern "C"
      * @param n the index of the item to get. Range is [0, array_size[
      * @return the nth item or NULL if node is not of type #PLIST_ARRAY
      */
-    plist_t plist_array_get_item(plist_t node, uint32_t n);
+    PLIST_API_MSC plist_t plist_array_get_item(plist_t node, uint32_t n);
 
     /**
      * Get the index of an item. item must be a member of a #PLIST_ARRAY node.
@@ -255,7 +261,7 @@ extern "C"
      * @param node the node
      * @return the node index
      */
-    uint32_t plist_array_get_item_index(plist_t node);
+    PLIST_API_MSC uint32_t plist_array_get_item_index(plist_t node);
 
     /**
      * Set the nth item in a #PLIST_ARRAY node.
@@ -265,7 +271,7 @@ extern "C"
      * @param item the new item at index n. The array is responsible for freeing item when it is no longer needed.
      * @param n the index of the item to get. Range is [0, array_size[. Assert if n is not in range.
      */
-    void plist_array_set_item(plist_t node, plist_t item, uint32_t n);
+    PLIST_API_MSC void plist_array_set_item(plist_t node, plist_t item, uint32_t n);
 
     /**
      * Append a new item at the end of a #PLIST_ARRAY node.
@@ -273,7 +279,7 @@ extern "C"
      * @param node the node of type #PLIST_ARRAY
      * @param item the new item. The array is responsible for freeing item when it is no longer needed.
      */
-    void plist_array_append_item(plist_t node, plist_t item);
+    PLIST_API_MSC void plist_array_append_item(plist_t node, plist_t item);
 
     /**
      * Insert a new item at position n in a #PLIST_ARRAY node.
@@ -282,7 +288,7 @@ extern "C"
      * @param item the new item to insert. The array is responsible for freeing item when it is no longer needed.
      * @param n The position at which the node will be stored. Range is [0, array_size[. Assert if n is not in range.
      */
-    void plist_array_insert_item(plist_t node, plist_t item, uint32_t n);
+    PLIST_API_MSC void plist_array_insert_item(plist_t node, plist_t item, uint32_t n);
 
     /**
      * Remove an existing position in a #PLIST_ARRAY node.
@@ -291,7 +297,7 @@ extern "C"
      * @param node the node of type #PLIST_ARRAY
      * @param n The position to remove. Range is [0, array_size[. Assert if n is not in range.
      */
-    void plist_array_remove_item(plist_t node, uint32_t n);
+    PLIST_API_MSC void plist_array_remove_item(plist_t node, uint32_t n);
 
     /********************************************
      *                                          *
@@ -305,7 +311,7 @@ extern "C"
      * @param node the node of type #PLIST_DICT
      * @return size of the #PLIST_DICT node
      */
-    uint32_t plist_dict_get_size(plist_t node);
+    PLIST_API_MSC uint32_t plist_dict_get_size(plist_t node);
 
     /**
      * Create an iterator of a #PLIST_DICT node.
@@ -314,7 +320,7 @@ extern "C"
      * @param node the node of type #PLIST_DICT
      * @param iter iterator of the #PLIST_DICT node
      */
-    void plist_dict_new_iter(plist_t node, plist_dict_iter *iter);
+    PLIST_API_MSC void plist_dict_new_iter(plist_t node, plist_dict_iter *iter);
 
     /**
      * Increment iterator of a #PLIST_DICT node.
@@ -326,7 +332,7 @@ extern "C"
      * @param val a location to store the value, or NULL. The caller should *not*
      *		free the returned value.
      */
-    void plist_dict_next_item(plist_t node, plist_dict_iter iter, char **key, plist_t *val);
+    PLIST_API_MSC void plist_dict_next_item(plist_t node, plist_dict_iter iter, char **key, plist_t *val);
 
     /**
      * Get key associated to an item. Item must be member of a dictionary
@@ -334,7 +340,7 @@ extern "C"
      * @param node the node
      * @param key a location to store the key. The caller is responsible for freeing the returned string.
      */
-    void plist_dict_get_item_key(plist_t node, char **key);
+    PLIST_API_MSC void plist_dict_get_item_key(plist_t node, char **key);
 
     /**
      * Get the nth item in a #PLIST_DICT node.
@@ -344,7 +350,7 @@ extern "C"
      * @return the item or NULL if node is not of type #PLIST_DICT. The caller should not free
      *		the returned node.
      */
-    plist_t plist_dict_get_item(plist_t node, const char* key);
+    PLIST_API_MSC plist_t plist_dict_get_item(plist_t node, const char* key);
 
     /**
      * Set item identified by key in a #PLIST_DICT node.
@@ -355,7 +361,7 @@ extern "C"
      * @param item the new item associated to key
      * @param key the identifier of the item to set.
      */
-    void plist_dict_set_item(plist_t node, const char* key, plist_t item);
+    PLIST_API_MSC void plist_dict_set_item(plist_t node, const char* key, plist_t item);
 
     /**
      * Insert a new item into a #PLIST_DICT node.
@@ -367,7 +373,7 @@ extern "C"
      * @param key The identifier of the item to insert.
      */
     PLIST_WARN_DEPRECATED("use plist_dict_set_item instead")
-    void plist_dict_insert_item(plist_t node, const char* key, plist_t item);
+    PLIST_API_MSC void plist_dict_insert_item(plist_t node, const char* key, plist_t item);
 
     /**
      * Remove an existing position in a #PLIST_DICT node.
@@ -376,7 +382,7 @@ extern "C"
      * @param node the node of type #PLIST_DICT
      * @param key The identifier of the item to remove. Assert if identifier is not present.
      */
-    void plist_dict_remove_item(plist_t node, const char* key);
+    PLIST_API_MSC void plist_dict_remove_item(plist_t node, const char* key);
 
     /**
      * Merge a dictionary into another. This will add all key/value pairs
@@ -386,7 +392,7 @@ extern "C"
      * @param target pointer to an existing node of type #PLIST_DICT
      * @param source node of type #PLIST_DICT that should be merged into target
      */
-    void plist_dict_merge(plist_t *target, plist_t source);
+    PLIST_API_MSC void plist_dict_merge(plist_t *target, plist_t source);
 
 
     /********************************************
@@ -400,7 +406,7 @@ extern "C"
      *
      * @param node the parent (NULL if node is root)
      */
-    plist_t plist_get_parent(plist_t node);
+    PLIST_API_MSC plist_t plist_get_parent(plist_t node);
 
     /**
      * Get the #plist_type of a node.
@@ -408,7 +414,7 @@ extern "C"
      * @param node the node
      * @return the type of the node
      */
-    plist_type plist_get_node_type(plist_t node);
+    PLIST_API_MSC plist_type plist_get_node_type(plist_t node);
 
     /**
      * Get the value of a #PLIST_KEY node.
@@ -418,7 +424,7 @@ extern "C"
      * @param val a pointer to a C-string. This function allocates the memory,
      *            caller is responsible for freeing it.
      */
-    void plist_get_key_val(plist_t node, char **val);
+    PLIST_API_MSC void plist_get_key_val(plist_t node, char **val);
 
     /**
      * Get the value of a #PLIST_STRING node.
@@ -428,7 +434,7 @@ extern "C"
      * @param val a pointer to a C-string. This function allocates the memory,
      *            caller is responsible for freeing it. Data is UTF-8 encoded.
      */
-    void plist_get_string_val(plist_t node, char **val);
+    PLIST_API_MSC void plist_get_string_val(plist_t node, char **val);
 
     /**
      * Get the value of a #PLIST_BOOLEAN node.
@@ -437,7 +443,7 @@ extern "C"
      * @param node the node
      * @param val a pointer to a uint8_t variable.
      */
-    void plist_get_bool_val(plist_t node, uint8_t * val);
+    PLIST_API_MSC void plist_get_bool_val(plist_t node, uint8_t * val);
 
     /**
      * Get the value of a #PLIST_UINT node.
@@ -446,7 +452,7 @@ extern "C"
      * @param node the node
      * @param val a pointer to a uint64_t variable.
      */
-    void plist_get_uint_val(plist_t node, uint64_t * val);
+    PLIST_API_MSC void plist_get_uint_val(plist_t node, uint64_t * val);
 
     /**
      * Get the value of a #PLIST_REAL node.
@@ -455,7 +461,7 @@ extern "C"
      * @param node the node
      * @param val a pointer to a double variable.
      */
-    void plist_get_real_val(plist_t node, double *val);
+    PLIST_API_MSC void plist_get_real_val(plist_t node, double *val);
 
     /**
      * Get the value of a #PLIST_DATA node.
@@ -466,7 +472,7 @@ extern "C"
      *            caller is responsible for freeing it.
      * @param length the length of the buffer
      */
-    void plist_get_data_val(plist_t node, char **val, uint64_t * length);
+    PLIST_API_MSC void plist_get_data_val(plist_t node, char **val, uint64_t * length);
 
     /**
      * Get the value of a #PLIST_DATE node.
@@ -476,7 +482,7 @@ extern "C"
      * @param sec a pointer to an int32_t variable. Represents the number of seconds since 01/01/2001.
      * @param usec a pointer to an int32_t variable. Represents the number of microseconds
      */
-    void plist_get_date_val(plist_t node, int32_t * sec, int32_t * usec);
+    PLIST_API_MSC void plist_get_date_val(plist_t node, int32_t * sec, int32_t * usec);
 
     /**
      * Get the value of a #PLIST_UID node.
@@ -485,7 +491,7 @@ extern "C"
      * @param node the node
      * @param val a pointer to a uint64_t variable.
      */
-    void plist_get_uid_val(plist_t node, uint64_t * val);
+    PLIST_API_MSC void plist_get_uid_val(plist_t node, uint64_t * val);
 
 
     /********************************************
@@ -501,7 +507,7 @@ extern "C"
      * @param node the node
      * @param val the key value
      */
-    void plist_set_key_val(plist_t node, const char *val);
+    PLIST_API_MSC void plist_set_key_val(plist_t node, const char *val);
 
     /**
      * Set the value of a node.
@@ -511,7 +517,7 @@ extern "C"
      * @param val the string value. The string is copied when set and will be
      *		freed by the node.
      */
-    void plist_set_string_val(plist_t node, const char *val);
+    PLIST_API_MSC void plist_set_string_val(plist_t node, const char *val);
 
     /**
      * Set the value of a node.
@@ -520,7 +526,7 @@ extern "C"
      * @param node the node
      * @param val the boolean value
      */
-    void plist_set_bool_val(plist_t node, uint8_t val);
+    PLIST_API_MSC void plist_set_bool_val(plist_t node, uint8_t val);
 
     /**
      * Set the value of a node.
@@ -529,7 +535,7 @@ extern "C"
      * @param node the node
      * @param val the unsigned integer value
      */
-    void plist_set_uint_val(plist_t node, uint64_t val);
+    PLIST_API_MSC void plist_set_uint_val(plist_t node, uint64_t val);
 
     /**
      * Set the value of a node.
@@ -538,7 +544,7 @@ extern "C"
      * @param node the node
      * @param val the real value
      */
-    void plist_set_real_val(plist_t node, double val);
+    PLIST_API_MSC void plist_set_real_val(plist_t node, double val);
 
     /**
      * Set the value of a node.
@@ -549,7 +555,7 @@ extern "C"
      *		be freed by the node.
      * @param length the length of the buffer
      */
-    void plist_set_data_val(plist_t node, const char *val, uint64_t length);
+    PLIST_API_MSC void plist_set_data_val(plist_t node, const char *val, uint64_t length);
 
     /**
      * Set the value of a node.
@@ -559,7 +565,7 @@ extern "C"
      * @param sec the number of seconds since 01/01/2001
      * @param usec the number of microseconds
      */
-    void plist_set_date_val(plist_t node, int32_t sec, int32_t usec);
+    PLIST_API_MSC void plist_set_date_val(plist_t node, int32_t sec, int32_t usec);
 
     /**
      * Set the value of a node.
@@ -568,7 +574,7 @@ extern "C"
      * @param node the node
      * @param val the unsigned integer value
      */
-    void plist_set_uid_val(plist_t node, uint64_t val);
+    PLIST_API_MSC void plist_set_uid_val(plist_t node, uint64_t val);
 
 
     /********************************************
@@ -585,7 +591,14 @@ extern "C"
      *            caller is responsible for freeing it. Data is UTF-8 encoded.
      * @param length a pointer to an uint32_t variable. Represents the length of the allocated buffer.
      */
-    void plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length);
+    PLIST_API_MSC void plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length);
+
+    /**
+    * Frees the memory allocated by plist_to_xml
+    *
+    * @param plist_bin The object allocated by plist_to_xml
+    */
+    PLIST_API_MSC void plist_to_xml_free(char **plist_xml);
 
     /**
      * Export the #plist_t structure to binary format.
@@ -595,7 +608,14 @@ extern "C"
      *            caller is responsible for freeing it.
      * @param length a pointer to an uint32_t variable. Represents the length of the allocated buffer.
      */
-    void plist_to_bin(plist_t plist, char **plist_bin, uint32_t * length);
+    PLIST_API_MSC void plist_to_bin(plist_t plist, char **plist_bin, uint32_t * length);
+
+    /**
+      * Frees the memory allocated by plist_to_bin
+      *
+      * @param plist_bin The object allocated by plist_to_bin
+      */
+    PLIST_API_MSC void plist_to_bin_free(char **plist_bin);
 
     /**
      * Import the #plist_t structure from XML format.
@@ -604,7 +624,7 @@ extern "C"
      * @param length length of the buffer to read.
      * @param plist a pointer to the imported plist.
      */
-    void plist_from_xml(const char *plist_xml, uint32_t length, plist_t * plist);
+    PLIST_API_MSC void plist_from_xml(const char *plist_xml, uint32_t length, plist_t * plist);
 
     /**
      * Import the #plist_t structure from binary format.
@@ -613,7 +633,7 @@ extern "C"
      * @param length length of the buffer to read.
      * @param plist a pointer to the imported plist.
      */
-    void plist_from_bin(const char *plist_bin, uint32_t length, plist_t * plist);
+    PLIST_API_MSC void plist_from_bin(const char *plist_bin, uint32_t length, plist_t * plist);
 
     /**
      * Import the #plist_t structure from memory data.
@@ -655,7 +675,7 @@ extern "C"
      * @param length length of the path to access
      * @return the value to access.
      */
-    plist_t plist_access_path(plist_t plist, uint32_t length, ...);
+    PLIST_API_MSC plist_t plist_access_path(plist_t plist, uint32_t length, ...);
 
     /**
      * Variadic version of #plist_access_path.
@@ -665,7 +685,7 @@ extern "C"
      * @param v list of array's index and dic'st key
      * @return the value to access.
      */
-    plist_t plist_access_pathv(plist_t plist, uint32_t length, va_list v);
+    PLIST_API_MSC plist_t plist_access_pathv(plist_t plist, uint32_t length, va_list v);
 
     /**
      * Compare two node values
@@ -674,7 +694,7 @@ extern "C"
      * @param node_r rigth node to compare
      * @return TRUE is type and value match, FALSE otherwise.
      */
-    char plist_compare_node_value(plist_t node_l, plist_t node_r);
+    PLIST_API_MSC char plist_compare_node_value(plist_t node_l, plist_t node_r);
 
     /*@}*/
 

--- a/src/bplist.c
+++ b/src/bplist.c
@@ -189,32 +189,23 @@ static uint32_t uint24_from_be(union plist_uint_ptr buf)
 #else
 uint64_t get_unaligned_64(uint64_t *ptr)
 {
-#pragma pack(push, 1)
-    struct packed {
-        uint64_t __v;
-    } *__p = (packed *)(ptr);
-#pragma pack(pop)	
-    return __p->__v;
+	uint64_t temp;
+	memcpy(&temp, ptr, sizeof(temp));
+	return temp;
 }
 
 uint32_t get_unaligned_32(uint32_t *ptr)
 {
-#pragma pack(push, 1)	
-    struct packed {
-        uint32_t __v;
-    } *__p = (packed *)(ptr);
-#pragma pack(pop)
-    return __p->__v;
+	uint32_t temp;
+	memcpy(&temp, ptr, sizeof(temp));
+	return temp;
 }
 
 uint16_t get_unaligned_16(uint16_t *ptr)
 {
-#pragma pack(push, 1)	
-    struct packed {
-        uint16_t __v;
-    } *__p = (packed *)(ptr);
-#pragma pack(pop)	
-    return __p->__v;
+	uint16_t temp;
+	memcpy(&temp, ptr, sizeof(temp));
+	return temp;
 }
 
 uint64_t UINT_TO_HOST(void *x, uint8_t n)

--- a/src/bplist.c
+++ b/src/bplist.c
@@ -175,6 +175,7 @@ static uint32_t uint24_from_be(union plist_uint_ptr buf)
 #endif
 #endif
 
+#ifndef _MSC_VER
 #define UINT_TO_HOST(x, n) \
 	({ \
 		union plist_uint_ptr __up; \
@@ -185,13 +186,64 @@ static uint32_t uint24_from_be(union plist_uint_ptr buf)
 		(n == 2 ? be16toh( get_unaligned(__up.u16ptr) ) : \
 		*__up.u8ptr )))); \
 	})
+#else
+uint64_t get_unaligned_64(uint64_t *ptr)
+{
+#pragma pack(push, 1)
+    struct packed {
+        uint64_t __v;
+    } *__p = (packed *)(ptr);
+#pragma pack(pop)	
+    return __p->__v;
+}
 
+uint32_t get_unaligned_32(uint32_t *ptr)
+{
+#pragma pack(push, 1)	
+    struct packed {
+        uint32_t __v;
+    } *__p = (packed *)(ptr);
+#pragma pack(pop)
+    return __p->__v;
+}
+
+uint16_t get_unaligned_16(uint16_t *ptr)
+{
+#pragma pack(push, 1)	
+    struct packed {
+        uint16_t __v;
+    } *__p = (packed *)(ptr);
+#pragma pack(pop)	
+    return __p->__v;
+}
+
+uint64_t UINT_TO_HOST(void *x, uint8_t n)
+{
+    union plist_uint_ptr __up;
+    __up.src = x;
+    return (n == 8 ? be64toh(get_unaligned_64(__up.u64ptr)) :
+        (n == 4 ? be32toh(get_unaligned_32(__up.u32ptr)) :
+        (n == 3 ? uint24_from_be(__up) :
+        (n == 2 ? be16toh(get_unaligned_16(__up.u16ptr)) :
+        *__up.u8ptr))));
+}
+#endif
+
+#ifndef _MSC_VER
 #define be64dec(x) \
 	({ \
 		union plist_uint_ptr __up; \
 		__up.src = x; \
 		be64toh( get_unaligned(__up.u64ptr) ); \
 	})
+#else
+uint64_t be64dec(char *x)
+{
+    union plist_uint_ptr __up;
+    __up.src = x;
+    return be64toh(get_unaligned_64(__up.u64ptr));
+}
+#endif
 
 #define get_needed_bytes(x) \
 		( ((uint64_t)x) < (1ULL << 8) ? 1 : \

--- a/src/bplist.c
+++ b/src/bplist.c
@@ -254,7 +254,7 @@ static plist_t parse_real_node(const char **bnode, uint8_t size)
     uint8_t* buf;
 
     size = 1 << size;			// make length less misleading
-    buf = malloc (size);
+    buf = (uint8_t*)malloc (size);
     memcpy (buf, *bnode, size);
     switch (size)
     {
@@ -417,8 +417,8 @@ static plist_t parse_dict_node(struct bplist_data *bplist, const char** bnode, u
         str_i = j * bplist->dict_size;
         str_j = (j + size) * bplist->dict_size;
 
-        index1 = UINT_TO_HOST((*bnode) + str_i, bplist->dict_size);
-        index2 = UINT_TO_HOST((*bnode) + str_j, bplist->dict_size);
+        index1 = UINT_TO_HOST((void *)((*bnode) + str_i), bplist->dict_size);
+        index2 = UINT_TO_HOST((void *)((*bnode) + str_j), bplist->dict_size);
 
         if (index1 >= bplist->num_objects) {
             plist_free(node);
@@ -452,8 +452,8 @@ static plist_t parse_dict_node(struct bplist_data *bplist, const char** bnode, u
             return NULL;
         }
 
-        node_attach(node, key);
-        node_attach(node, val);
+        node_attach((node_t *)node, (node_t *)key);
+        node_attach((node_t *)node, (node_t *)val);
     }
 
     return node;
@@ -474,7 +474,7 @@ static plist_t parse_array_node(struct bplist_data *bplist, const char** bnode, 
 
     for (j = 0; j < data->length; j++) {
         str_j = j * bplist->dict_size;
-        index1 = UINT_TO_HOST((*bnode) + str_j, bplist->dict_size);
+        index1 = UINT_TO_HOST((void *)((*bnode) + str_j), bplist->dict_size);
 
         if (index1 >= bplist->num_objects) {
             plist_free(node);
@@ -488,7 +488,7 @@ static plist_t parse_array_node(struct bplist_data *bplist, const char** bnode, 
             return NULL;
         }
 
-        node_attach(node, val);
+        node_attach((node_t *)node, (node_t *)val);
     }
 
     return node;
@@ -638,7 +638,7 @@ static plist_t parse_bin_node_at_index(struct bplist_data *bplist, uint32_t node
     const char* ptr;
     plist_t plist;
 
-    ptr = bplist->data + UINT_TO_HOST(bplist->offset_table + node_index * bplist->offset_size, bplist->offset_size);
+    ptr = bplist->data + UINT_TO_HOST((void *)(bplist->offset_table + node_index * bplist->offset_size), bplist->offset_size);
     /* make sure the node offset is in a sane range */
     if ((ptr < bplist->data) || (ptr >= bplist->offset_table)) {
         return NULL;
@@ -1114,7 +1114,7 @@ PLIST_API void plist_to_bin(plist_t plist, char **plist_bin, uint32_t * length)
     //serialize plist
     ser_s.objects = objects;
     ser_s.ref_table = ref_table;
-    serialize_plist(plist, &ser_s);
+    serialize_plist((node_t*)plist, &ser_s);
 
     //now stream to output buffer
     offset_size = 0;			//unknown yet
@@ -1177,10 +1177,10 @@ PLIST_API void plist_to_bin(plist_t plist, char **plist_bin, uint32_t * length)
         case PLIST_DATA:
             write_data(bplist_buff, data->buff, data->length);
         case PLIST_ARRAY:
-            write_array(bplist_buff, ptr_array_index(objects, i), ref_table, dict_param_size);
+            write_array(bplist_buff, (node_t*)ptr_array_index(objects, i), ref_table, dict_param_size);
             break;
         case PLIST_DICT:
-            write_dict(bplist_buff, ptr_array_index(objects, i), ref_table, dict_param_size);
+            write_dict(bplist_buff, (node_t*)ptr_array_index(objects, i), ref_table, dict_param_size);
             break;
         case PLIST_DATE:
             write_date(bplist_buff, data->timeval.tv_sec + (double) data->timeval.tv_usec / 1000000);

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -44,7 +44,7 @@ void hash_table_destroy(hashtable_t *ht)
 			while (e) {
 				free(e->value);
 				hashentry_t* old = e;
-				e = e->next;
+				e = (hashentry_t*)e->next;
 				free(old);
 			}
 		}
@@ -68,7 +68,7 @@ void hash_table_insert(hashtable_t* ht, void *key, void *value)
 			e->value = value;
 			return;
 		}
-		e = e->next;
+		e = (hashentry_t*)e->next;
 	}
 
 	// if we get here, the element is not yet in the list.
@@ -100,7 +100,7 @@ void* hash_table_lookup(hashtable_t* ht, void *key)
 		if (ht->compare_func(e->key, key)) {
 			return e->value;
 		}
-		e = e->next;
+		e = (hashentry_t*)e->next;
 	}
 	return NULL;
 }

--- a/src/msc_config.h
+++ b/src/msc_config.h
@@ -1,0 +1,28 @@
+/*
+* msc_config.h
+* Contains definitions that will help the Visual C++ compiler compile
+* the libimobiledevice code base.
+*
+* Copyright (c) 2015 Frederik Carlier, Quamotion bvba. All Rights Reserved.
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifdef _MSC_VER
+#define inline __inline
+#define WIN32_LEAN_AND_MEAN
+#define _CRT_SECURE_NO_WARNINGS
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+#endif

--- a/src/plist.c
+++ b/src/plist.c
@@ -82,7 +82,7 @@ plist_data_t plist_get_data(const plist_t node)
 {
     if (!node)
         return NULL;
-    return ((node_t*)node)->data;
+    return (plist_data_t)((node_t*)node)->data;
 }
 
 plist_data_t plist_new_plist_data(void)
@@ -224,7 +224,7 @@ PLIST_API void plist_free(plist_t plist)
 {
     if (plist)
     {
-        plist_free_node(plist);
+        plist_free_node((node_t*)plist);
     }
 }
 
@@ -260,7 +260,7 @@ static void plist_copy_node(node_t *node, void *parent_node_ptr)
 
     if (*(plist_t*)parent_node_ptr)
     {
-        node_attach(*(plist_t*)parent_node_ptr, newnode);
+        node_attach((node_t*)(*(plist_t*)parent_node_ptr), (node_t*)newnode);
     }
     else
     {
@@ -278,7 +278,7 @@ static void plist_copy_node(node_t *node, void *parent_node_ptr)
 PLIST_API plist_t plist_copy(plist_t node)
 {
     plist_t copied = NULL;
-    plist_copy_node(node, &copied);
+    plist_copy_node((node_t*)node, &copied);
     return copied;
 }
 
@@ -287,7 +287,7 @@ PLIST_API uint32_t plist_array_get_size(plist_t node)
     uint32_t ret = 0;
     if (node && PLIST_ARRAY == plist_get_node_type(node))
     {
-        ret = node_n_children(node);
+        ret = node_n_children((node_t*)node);
     }
     return ret;
 }
@@ -297,7 +297,7 @@ PLIST_API plist_t plist_array_get_item(plist_t node, uint32_t n)
     plist_t ret = NULL;
     if (node && PLIST_ARRAY == plist_get_node_type(node))
     {
-        ret = (plist_t)node_nth_child(node, n);
+        ret = (plist_t)node_nth_child((node_t*)node, n);
     }
     return ret;
 }
@@ -307,7 +307,7 @@ PLIST_API uint32_t plist_array_get_item_index(plist_t node)
     plist_t father = plist_get_parent(node);
     if (PLIST_ARRAY == plist_get_node_type(father))
     {
-        return node_child_position(father, node);
+        return node_child_position((node_t*)father, (node_t*)node);
     }
     return 0;
 }
@@ -319,11 +319,11 @@ PLIST_API void plist_array_set_item(plist_t node, plist_t item, uint32_t n)
         plist_t old_item = plist_array_get_item(node, n);
         if (old_item)
         {
-            int idx = plist_free_node(old_item);
-	    if (idx < 0) {
-		node_attach(node, item);
+            int idx = plist_free_node((node_t*)old_item);
+	        if (idx < 0) {
+		node_attach((node_t*)node, (node_t*)item);
 	    } else {
-		node_insert(node, idx, item);
+		node_insert((node_t*)node, idx, (node_t*)item);
 	    }
         }
     }
@@ -334,7 +334,7 @@ PLIST_API void plist_array_append_item(plist_t node, plist_t item)
 {
     if (node && PLIST_ARRAY == plist_get_node_type(node))
     {
-        node_attach(node, item);
+        node_attach((node_t*)node, (node_t*)item);
     }
     return;
 }
@@ -343,7 +343,7 @@ PLIST_API void plist_array_insert_item(plist_t node, plist_t item, uint32_t n)
 {
     if (node && PLIST_ARRAY == plist_get_node_type(node))
     {
-        node_insert(node, n, item);
+        node_insert((node_t*)node, n, (node_t*)item);
     }
     return;
 }
@@ -366,7 +366,7 @@ PLIST_API uint32_t plist_dict_get_size(plist_t node)
     uint32_t ret = 0;
     if (node && PLIST_DICT == plist_get_node_type(node))
     {
-        ret = node_n_children(node) / 2;
+        ret = node_n_children((node_t*)node) / 2;
     }
     return ret;
 }
@@ -394,17 +394,17 @@ PLIST_API void plist_dict_next_item(plist_t node, plist_dict_iter iter, char **k
         *val = NULL;
     }
 
-    if (node && PLIST_DICT == plist_get_node_type(node) && *iter_int < node_n_children(node))
+    if (node && PLIST_DICT == plist_get_node_type(node) && *iter_int < node_n_children((node_t*)node))
     {
 
         if (key)
         {
-            plist_get_key_val((plist_t)node_nth_child(node, *iter_int), key);
+            plist_get_key_val((plist_t)node_nth_child((node_t*)node, *iter_int), key);
         }
 
         if (val)
         {
-            *val = (plist_t) node_nth_child(node, *iter_int + 1);
+            *val = (plist_t) node_nth_child((node_t*)node, *iter_int + 1);
         }
 
         *iter_int += 2;
@@ -417,7 +417,7 @@ PLIST_API void plist_dict_get_item_key(plist_t node, char **key)
     plist_t father = plist_get_parent(node);
     if (PLIST_DICT == plist_get_node_type(father))
     {
-        plist_get_key_val( (plist_t) node_prev_sibling(node), key);
+        plist_get_key_val( (plist_t) node_prev_sibling((node_t*)node), key);
     }
 }
 
@@ -429,9 +429,9 @@ PLIST_API plist_t plist_dict_get_item(plist_t node, const char* key)
     {
 
         plist_t current = NULL;
-        for (current = (plist_t)node_first_child(node);
+        for (current = (plist_t)node_first_child((node_t*)node);
                 current;
-                current = (plist_t)node_next_sibling(node_next_sibling(current)))
+                current = (plist_t)node_next_sibling(node_next_sibling((node_t*)current)))
         {
 
             plist_data_t data = plist_get_data(current);
@@ -439,7 +439,7 @@ PLIST_API plist_t plist_dict_get_item(plist_t node, const char* key)
 
             if (data && !strcmp(key, data->strval))
             {
-                ret = (plist_t)node_next_sibling(current);
+                ret = (plist_t)node_next_sibling((node_t*)current);
                 break;
             }
         }
@@ -450,17 +450,17 @@ PLIST_API plist_t plist_dict_get_item(plist_t node, const char* key)
 PLIST_API void plist_dict_set_item(plist_t node, const char* key, plist_t item)
 {
     if (node && PLIST_DICT == plist_get_node_type(node)) {
-        node_t* old_item = plist_dict_get_item(node, key);
+        node_t* old_item = (node_t*)plist_dict_get_item(node, key);
         if (old_item) {
             int idx = plist_free_node(old_item);
             if (idx < 0) {
-                node_attach(node, item);
+                node_attach((node_t*)node, (node_t*)item);
             } else {
-                node_insert(node, idx, item);
+                node_insert((node_t*)node, idx, (node_t*)item);
             }
         } else {
-            node_attach(node, plist_new_key(key));
-            node_attach(node, item);
+            node_attach((node_t*)node, (node_t*)plist_new_key(key));
+            node_attach((node_t*)node, (node_t*)item);
         }
     }
     return;
@@ -478,7 +478,7 @@ PLIST_API void plist_dict_remove_item(plist_t node, const char* key)
         plist_t old_item = plist_dict_get_item(node, key);
         if (old_item)
         {
-            plist_t key_node = node_prev_sibling(old_item);
+            plist_t key_node = node_prev_sibling((node_t*)old_item);
             plist_free(key_node);
             plist_free(old_item);
         }

--- a/src/plist.h
+++ b/src/plist.h
@@ -30,11 +30,13 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/time.h>
 
 #ifdef _MSC_VER
 #pragma warning(disable:4996)
 #pragma warning(disable:4244)
+#include <winsock2.h>
+#else
+#include <sys/time.h>
 #endif
 
 #ifdef WIN32

--- a/src/plist.h
+++ b/src/plist.h
@@ -39,6 +39,9 @@
 #include <sys/time.h>
 #endif
 
+#ifdef _MSC_VER
+  #define PLIST_API __declspec( dllexport )
+#else
 #ifdef WIN32
   #define PLIST_API __declspec( dllexport )
 #else
@@ -47,6 +50,7 @@
   #else
     #define PLIST_API
   #endif
+#endif
 #endif
 
 struct plist_data_s

--- a/src/ptrarray.c
+++ b/src/ptrarray.c
@@ -44,7 +44,7 @@ void ptr_array_add(ptrarray_t *pa, void *data)
 	if (!pa || !pa->pdata || !data) return;
 	size_t remaining = pa->capacity-pa->len;
 	if (remaining == 0) {
-		pa->pdata = realloc(pa->pdata, sizeof(void*) * (pa->capacity + pa->capacity_step));
+		pa->pdata = (void **)realloc(pa->pdata, sizeof(void*) * (pa->capacity + pa->capacity_step));
 		pa->capacity += pa->capacity_step;
 	}
 	pa->pdata[pa->len] = data;

--- a/src/xplist.c
+++ b/src/xplist.c
@@ -21,6 +21,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifdef _MSC_VER
+#include "msc_config.h"
+#endif
 
 #include <string.h>
 #include <assert.h>

--- a/src/xplist.c
+++ b/src/xplist.c
@@ -388,7 +388,7 @@ static void xml_to_node(xmlNodePtr xml_node, plist_t * plist_node)
         data = plist_new_plist_data();
         subnode = plist_new_node(data);
         if (*plist_node)
-            node_attach(*plist_node, subnode);
+            node_attach((node_t*)*plist_node, (node_t*)subnode);
         else
             *plist_node = subnode;
 
@@ -559,7 +559,7 @@ PLIST_API void plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length)
     root_node = xmlDocGetRootElement(plist_doc);
     root.xml = root_node;
 
-    node_to_xml(plist, &root);
+    node_to_xml((node_t*)plist, &root);
 
     xmlChar* tmp = NULL;
     xmlDocDumpMemory(plist_doc, &tmp, &size);

--- a/src/xplist.c
+++ b/src/xplist.c
@@ -159,7 +159,7 @@ static void dtostr(char *buf, size_t bufsize, double realval)
     size_t p;
 
     f = modf(f, &ip);
-    len = snprintf(buf, bufsize, "%s%"PRIi64, ((f < 0) && (ip >= 0)) ? "-" : "", (int64_t)ip);
+    len = snprintf(buf, bufsize, "%s%" PRIi64, ((f < 0) && (ip >= 0)) ? "-" : "", (int64_t)ip);
     if (len >= bufsize) {
         return;
     }
@@ -218,9 +218,9 @@ static void node_to_xml(node_t* node, void *xml_struct)
         tag = XPLIST_INT;
         val = (char*)malloc(64);
         if (node_data->length == 16) {
-	        (void)snprintf(val, 64, "%"PRIu64, node_data->intval);
+	        (void)snprintf(val, 64, "%" PRIu64, node_data->intval);
 	} else {
-	        (void)snprintf(val, 64, "%"PRIi64, node_data->intval);
+	        (void)snprintf(val, 64, "%" PRIi64, node_data->intval);
 	}
         break;
 


### PR DESCRIPTION
This is a rebased version of #63 and should do pretty much the same thing as #69, #49, #4 and #5 .

This pull request adds support for Microsoft Visual C++ in libplist.

It only includes changes in the .h and .c files; the actual project files are not included to keep the libplist repository clean.

A lot of the changes are minor; for example, VC++ is more picky about implicit casts so a lot of cast statements have been added. Similarly, if the declaration in the .h and .c file differ, VC++ complains. Hence a lot of PLIST_API_MSC statements have been added in the .h files.

Care has been taken to make sure that VC++ -specific statements are wrapped in an #ifdef _MVC_VER statement, so that they won't interfere with other compilers on the Windows platform.

I used Travis as a CI server in the upstream repository, to verify compilation still works on the Linux platform. It did, and you can see the result here: https://travis-ci.org/libimobiledevice-win32/libplist/builds/130135945
The upstream repository also contains a sample .travis.yml file that you could use if you wanted CI; it is not included in this pull request.

Similarly, I also tested on a Windows machine using AppVeyor and you can see the results here: https://ci.appveyor.com/project/qmfrederik/libplist/

All feedback is welcome,

Frederik.
