### PR TITLE
node_iterator_create: Avoid access null pointer

### DIFF
--- a/libcnary/node_iterator.c
+++ b/libcnary/node_iterator.c
@@ -47,7 +47,7 @@ node_iterator_t* node_iterator_create(node_list_t* list) {
 
 	iterator->end = NULL;
 	iterator->begin = NULL;
-	iterator->value = list->begin;
+	iterator->value = NULL;
 
 	iterator->list = NULL;
 	iterator->next = node_iterator_next;


### PR DESCRIPTION
When argument list is null list->begin is invalid address
Set iterator->value as list->begin in node_iterator_bind after argument is checked
