### PR TITLE
Initialize safe_year in time64.c

### DIFF
--- a/src/time64.c
+++ b/src/time64.c
@@ -346,11 +346,11 @@ static Year cycle_offset(Year year)
 */
 static int safe_year(const Year year)
 {
-    int safe_year;
+    int safe_year= (int)year;
     Year year_cycle;
 
     if( year >= MIN_SAFE_YEAR && year <= MAX_SAFE_YEAR ) {
-        return (int)year;
+        return safe_year;
     }
 
     year_cycle = year + cycle_offset(year);


### PR DESCRIPTION
Clang fails with stricter compilation options, because it thinks safe_year may be uninitialized at the return statement. The logic prevents it from being uninitialized, but probably worth the initialization to avoid the compiler error. The rest of libimobiledevice compiles successfully under the same options.