### PR TITLE
Issue #109: Fix cython Node.to_bin() decode

### DIFF
--- a/cython/plist.pyx
+++ b/cython/plist.pyx
@@ -116,7 +116,7 @@ cdef class Node:
         plist_to_bin(self._c_node, &out, &length)
 
         try:
-            return _from_string_and_size(out, length)
+            return bytes(out[:length])
         finally:
             if out != NULL:
                 libc.stdlib.free(out)


### PR DESCRIPTION
Don't convert the string to UTF-8, just bytes.