### PR TITLE
Use DLL_EXPORT condition for DllMain

### DIFF
--- a/src/plist.c
+++ b/src/plist.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <math.h>
 
-#ifdef WIN32
+#ifdef DLL_EXPORT
 #include <windows.h>
 #else
 #include <pthread.h>
@@ -56,7 +56,7 @@ static void internal_plist_deinit(void)
     plist_xml_deinit();
 }
 
-#ifdef WIN32
+#ifdef DLL_EXPORT
 
 typedef volatile struct {
     LONG lock;


### PR DESCRIPTION
This prevents `DllMain` from being included in the Windows static library.