### PR TITLE
Fixed bug in dictionary_fill

### DIFF
--- a/src/Dictionary.cpp
+++ b/src/Dictionary.cpp
@@ -28,7 +28,7 @@ Dictionary::Dictionary(Node* parent) : Structure(PLIST_DICT, parent)
 {
 }
 
-static void dictionary_fill(Dictionary *_this, std::map<std::string,Node*> map, plist_t node)
+static void dictionary_fill(Dictionary *_this, std::map<std::string,Node*> &map, plist_t node)
 {
     plist_dict_iter it = NULL;
     plist_dict_new_iter(node, &it);


### PR DESCRIPTION
Bug: when creating a new Dictionary object (for example through PList::Node::FromPlist(plist_t node) ), the dictionary_fill function is called from Dictionary() constructor in line 50. It seems that the intended way of calling dictionary_fill() is to pass the _map object by reference, however it is actually passed by value. Thus the changes to the map object made by dictionary_fill() are discarded when the function returns.

Fix: pass _map by reference to keep the changes