### PR TITLE
clang-tidy fixes

### DIFF
--- a/include/plist/Array.h
+++ b/include/plist/Array.h
@@ -34,7 +34,7 @@ public :
     Array(Node* parent = NULL);
     Array(plist_t node, Node* parent = NULL);
     Array(const Array& a);
-    Array& operator=(Array& a);
+    Array& operator=(const Array& a);
     virtual ~Array();
 
     Node* Clone() const;

--- a/include/plist/Array.h
+++ b/include/plist/Array.h
@@ -50,6 +50,6 @@ private :
     std::vector<Node*> _array;
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_ARRAY_H

--- a/include/plist/Array.h
+++ b/include/plist/Array.h
@@ -35,14 +35,14 @@ public :
     Array(plist_t node, Node* parent = NULL);
     Array(const Array& a);
     Array& operator=(const Array& a);
-    virtual ~Array();
+    ~Array() override;
 
-    Node* Clone() const;
+    Node* Clone() const override;
 
     Node* operator[](unsigned int index);
     void Append(Node* node);
     void Insert(Node* node, unsigned int pos);
-    void Remove(Node* node);
+    void Remove(Node* node) override;
     void Remove(unsigned int pos);
     unsigned int GetNodeIndex(Node* node) const;
 

--- a/include/plist/Boolean.h
+++ b/include/plist/Boolean.h
@@ -33,7 +33,7 @@ public :
     Boolean(Node* parent = NULL);
     Boolean(plist_t node, Node* parent = NULL);
     Boolean(const Boolean& b);
-    Boolean& operator=(Boolean& b);
+    Boolean& operator=(const Boolean& b);
     Boolean(bool b);
     virtual ~Boolean();
 

--- a/include/plist/Boolean.h
+++ b/include/plist/Boolean.h
@@ -43,6 +43,6 @@ public :
     bool GetValue() const;
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_BOOLEAN_H

--- a/include/plist/Boolean.h
+++ b/include/plist/Boolean.h
@@ -35,9 +35,9 @@ public :
     Boolean(const Boolean& b);
     Boolean& operator=(const Boolean& b);
     Boolean(bool b);
-    virtual ~Boolean();
+    ~Boolean() override;
 
-    Node* Clone() const;
+    Node* Clone() const override;
 
     void SetValue(bool b);
     bool GetValue() const;

--- a/include/plist/Data.h
+++ b/include/plist/Data.h
@@ -34,7 +34,7 @@ public :
     Data(Node* parent = NULL);
     Data(plist_t node, Node* parent = NULL);
     Data(const Data& d);
-    Data& operator=(Data& b);
+    Data& operator=(const Data& b);
     Data(const std::vector<char>& buff);
     virtual ~Data();
 

--- a/include/plist/Data.h
+++ b/include/plist/Data.h
@@ -34,7 +34,7 @@ public :
     Data(Node* parent = NULL);
     Data(plist_t node, Node* parent = NULL);
     Data(const Data& d);
-    Data& operator=(Data& d);
+    Data& operator=(Data& b);
     Data(const std::vector<char>& buff);
     virtual ~Data();
 

--- a/include/plist/Data.h
+++ b/include/plist/Data.h
@@ -44,6 +44,6 @@ public :
     std::vector<char> GetValue() const;
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_DATA_H

--- a/include/plist/Data.h
+++ b/include/plist/Data.h
@@ -36,9 +36,9 @@ public :
     Data(const Data& d);
     Data& operator=(const Data& b);
     Data(const std::vector<char>& buff);
-    virtual ~Data();
+    ~Data() override;
 
-    Node* Clone() const;
+    Node* Clone() const override;
 
     void SetValue(const std::vector<char>& buff);
     std::vector<char> GetValue() const;

--- a/include/plist/Date.h
+++ b/include/plist/Date.h
@@ -35,7 +35,7 @@ public :
     Date(Node* parent = NULL);
     Date(plist_t node, Node* parent = NULL);
     Date(const Date& d);
-    Date& operator=(Date& d);
+    Date& operator=(const Date& d);
     Date(timeval t);
     virtual ~Date();
 

--- a/include/plist/Date.h
+++ b/include/plist/Date.h
@@ -37,9 +37,9 @@ public :
     Date(const Date& d);
     Date& operator=(const Date& d);
     Date(timeval t);
-    virtual ~Date();
+    ~Date() override;
 
-    Node* Clone() const;
+    Node* Clone() const override;
 
     void SetValue(timeval t);
     timeval GetValue() const;

--- a/include/plist/Date.h
+++ b/include/plist/Date.h
@@ -45,6 +45,6 @@ public :
     timeval GetValue() const;
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_DATE_H

--- a/include/plist/Dictionary.h
+++ b/include/plist/Dictionary.h
@@ -35,7 +35,7 @@ public :
     Dictionary(Node* parent = NULL);
     Dictionary(plist_t node, Node* parent = NULL);
     Dictionary(const Dictionary& d);
-    Dictionary& operator=(Dictionary& d);
+    Dictionary& operator=(const Dictionary& d);
     virtual ~Dictionary();
 
     Node* Clone() const;

--- a/include/plist/Dictionary.h
+++ b/include/plist/Dictionary.h
@@ -55,7 +55,7 @@ public :
     iterator Insert(const std::string& key, Node* node) PLIST_WARN_DEPRECATED("use Set() instead");
     void Remove(Node* node);
     void Remove(const std::string& key);
-    std::string GetNodeKey(Node* key);
+    std::string GetNodeKey(Node* node);
 
 private :
     std::map<std::string,Node*> _map;

--- a/include/plist/Dictionary.h
+++ b/include/plist/Dictionary.h
@@ -36,9 +36,9 @@ public :
     Dictionary(plist_t node, Node* parent = NULL);
     Dictionary(const Dictionary& d);
     Dictionary& operator=(const Dictionary& d);
-    virtual ~Dictionary();
+    ~Dictionary() override;
 
-    Node* Clone() const;
+    Node* Clone() const override;
 
     typedef std::map<std::string,Node*>::iterator iterator;
     typedef std::map<std::string,Node*>::const_iterator const_iterator;
@@ -53,7 +53,7 @@ public :
     iterator Set(const std::string& key, const Node* node);
     iterator Set(const std::string& key, const Node& node);
     iterator Insert(const std::string& key, Node* node) PLIST_WARN_DEPRECATED("use Set() instead");
-    void Remove(Node* node);
+    void Remove(Node* node) override;
     void Remove(const std::string& key);
     std::string GetNodeKey(Node* node);
 

--- a/include/plist/Dictionary.h
+++ b/include/plist/Dictionary.h
@@ -63,6 +63,6 @@ private :
 
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_DICTIONARY_H

--- a/include/plist/Integer.h
+++ b/include/plist/Integer.h
@@ -33,7 +33,7 @@ public :
     Integer(Node* parent = NULL);
     Integer(plist_t node, Node* parent = NULL);
     Integer(const Integer& i);
-    Integer& operator=(Integer& i);
+    Integer& operator=(const Integer& i);
     Integer(uint64_t i);
     virtual ~Integer();
 

--- a/include/plist/Integer.h
+++ b/include/plist/Integer.h
@@ -35,9 +35,9 @@ public :
     Integer(const Integer& i);
     Integer& operator=(const Integer& i);
     Integer(uint64_t i);
-    virtual ~Integer();
+    ~Integer() override;
 
-    Node* Clone() const;
+    Node* Clone() const override;
 
     void SetValue(uint64_t i);
     uint64_t GetValue() const;

--- a/include/plist/Integer.h
+++ b/include/plist/Integer.h
@@ -43,6 +43,6 @@ public :
     uint64_t GetValue() const;
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_INTEGER_H

--- a/include/plist/Key.h
+++ b/include/plist/Key.h
@@ -33,8 +33,8 @@ class Key : public Node
 public :
     Key(Node* parent = NULL);
     Key(plist_t node, Node* parent = NULL);
-    Key(const Key& s);
-    Key& operator=(Key& s);
+    Key(const Key& k);
+    Key& operator=(Key& k);
     Key(const std::string& s);
     virtual ~Key();
 

--- a/include/plist/Key.h
+++ b/include/plist/Key.h
@@ -34,7 +34,7 @@ public :
     Key(Node* parent = NULL);
     Key(plist_t node, Node* parent = NULL);
     Key(const Key& k);
-    Key& operator=(Key& k);
+    Key& operator=(const Key& k);
     Key(const std::string& s);
     virtual ~Key();
 

--- a/include/plist/Key.h
+++ b/include/plist/Key.h
@@ -36,9 +36,9 @@ public :
     Key(const Key& k);
     Key& operator=(const Key& k);
     Key(const std::string& s);
-    virtual ~Key();
+    ~Key() override;
 
-    Node* Clone() const;
+    Node* Clone() const override;
 
     void SetValue(const std::string& s);
     std::string GetValue() const;

--- a/include/plist/Key.h
+++ b/include/plist/Key.h
@@ -44,6 +44,6 @@ public :
     std::string GetValue() const;
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_KEY_H

--- a/include/plist/Node.h
+++ b/include/plist/Node.h
@@ -52,6 +52,6 @@ private:
     friend class Structure;
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_NODE_H

--- a/include/plist/Real.h
+++ b/include/plist/Real.h
@@ -33,7 +33,7 @@ public :
     Real(Node* parent = NULL);
     Real(plist_t node, Node* parent = NULL);
     Real(const Real& d);
-    Real& operator=(Real& d);
+    Real& operator=(const Real& d);
     Real(double d);
     virtual ~Real();
 

--- a/include/plist/Real.h
+++ b/include/plist/Real.h
@@ -35,9 +35,9 @@ public :
     Real(const Real& d);
     Real& operator=(const Real& d);
     Real(double d);
-    virtual ~Real();
+    ~Real() override;
 
-    Node* Clone() const;
+    Node* Clone() const override;
 
     void SetValue(double d);
     double GetValue() const;

--- a/include/plist/Real.h
+++ b/include/plist/Real.h
@@ -43,6 +43,6 @@ public :
     double GetValue() const;
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_REAL_H

--- a/include/plist/String.h
+++ b/include/plist/String.h
@@ -34,7 +34,7 @@ public :
     String(Node* parent = NULL);
     String(plist_t node, Node* parent = NULL);
     String(const String& s);
-    String& operator=(String& s);
+    String& operator=(const String& s);
     String(const std::string& s);
     virtual ~String();
 

--- a/include/plist/String.h
+++ b/include/plist/String.h
@@ -44,6 +44,6 @@ public :
     std::string GetValue() const;
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_STRING_H

--- a/include/plist/String.h
+++ b/include/plist/String.h
@@ -36,9 +36,9 @@ public :
     String(const String& s);
     String& operator=(const String& s);
     String(const std::string& s);
-    virtual ~String();
+    ~String() override;
 
-    Node* Clone() const;
+    Node* Clone() const override;
 
     void SetValue(const std::string& s);
     std::string GetValue() const;

--- a/include/plist/Structure.h
+++ b/include/plist/Structure.h
@@ -54,6 +54,6 @@ private:
     Structure& operator=(const Structure& s);
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_STRUCTURE_H

--- a/include/plist/Structure.h
+++ b/include/plist/Structure.h
@@ -32,7 +32,7 @@ namespace PList
 class Structure : public Node
 {
 public :
-    virtual ~Structure();
+    ~Structure() override;
 
     uint32_t GetSize() const;
 

--- a/include/plist/Uid.h
+++ b/include/plist/Uid.h
@@ -33,7 +33,7 @@ public :
     Uid(Node* parent = NULL);
     Uid(plist_t node, Node* parent = NULL);
     Uid(const Uid& i);
-    Uid& operator=(Uid& i);
+    Uid& operator=(const Uid& i);
     Uid(uint64_t i);
     virtual ~Uid();
 

--- a/include/plist/Uid.h
+++ b/include/plist/Uid.h
@@ -43,6 +43,6 @@ public :
     uint64_t GetValue() const;
 };
 
-};
+}  // namespace PList
 
 #endif // PLIST_UID_H

--- a/include/plist/Uid.h
+++ b/include/plist/Uid.h
@@ -35,9 +35,9 @@ public :
     Uid(const Uid& i);
     Uid& operator=(const Uid& i);
     Uid(uint64_t i);
-    virtual ~Uid();
+    ~Uid() override;
 
-    Node* Clone() const;
+    Node* Clone() const override;
 
     void SetValue(uint64_t i);
     uint64_t GetValue() const;

--- a/include/plist/plist.h
+++ b/include/plist/plist.h
@@ -29,7 +29,7 @@ extern "C"
 {
 #endif
 
-#if _MSC_VER && _MSC_VER < 1700
+#if defined(_MSC_VER) && _MSC_VER < 1700
     typedef __int8 int8_t;
     typedef __int16 int16_t;
     typedef __int32 int32_t;

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -145,4 +145,4 @@ unsigned int Array::GetNodeIndex(Node* node) const
     return std::distance (_array.begin(), it);
 }
 
-};
+}  // namespace PList

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -61,9 +61,9 @@ Array::Array(const PList::Array& a) : Structure()
 Array& Array::operator=(PList::Array& a)
 {
     plist_free(_node);
-    for (unsigned int it = 0; it < _array.size(); it++)
+    for (auto & it : _array)
     {
-        delete _array.at(it);
+        delete it;
     }
     _array.clear();
     _node = plist_copy(a.GetPlist());
@@ -73,9 +73,9 @@ Array& Array::operator=(PList::Array& a)
 
 Array::~Array()
 {
-    for (unsigned int it = 0; it < _array.size(); it++)
+    for (auto & it : _array)
     {
-        delete (_array.at(it));
+        delete it;
     }
     _array.clear();
 }

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -58,7 +58,7 @@ Array::Array(const PList::Array& a)
     array_fill(this, _array, _node);
 }
 
-Array& Array::operator=(PList::Array& a)
+Array& Array::operator=(const PList::Array& a)
 {
     plist_free(_node);
     for (auto & it : _array)

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -18,11 +18,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/Array.h>
 
 #include <algorithm>
-#include <limits.h>
+#include <climits>
 
 namespace PList
 {

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -108,7 +108,7 @@ void Array::Insert(Node* node, unsigned int pos)
         Node* clone = node->Clone();
         UpdateNodeParent(clone);
         plist_array_insert_item(_node, clone->GetPlist(), pos);
-        std::vector<Node*>::iterator it = _array.begin();
+        auto it = _array.begin();
         it += pos;
         _array.insert(it, clone);
     }
@@ -123,7 +123,7 @@ void Array::Remove(Node* node)
             return;
         }
         plist_array_remove_item(_node, pos);
-        std::vector<Node*>::iterator it = _array.begin();
+        auto it = _array.begin();
         it += pos;
         _array.erase(it);
         delete node;
@@ -133,7 +133,7 @@ void Array::Remove(Node* node)
 void Array::Remove(unsigned int pos)
 {
     plist_array_remove_item(_node, pos);
-    std::vector<Node*>::iterator it = _array.begin();
+    auto it = _array.begin();
     it += pos;
     delete _array.at(pos);
     _array.erase(it);
@@ -141,7 +141,7 @@ void Array::Remove(unsigned int pos)
 
 unsigned int Array::GetNodeIndex(Node* node) const
 {
-    std::vector<Node*>::const_iterator it = std::find(_array.begin(), _array.end(), node);
+    auto it = std::find(_array.begin(), _array.end(), node);
     return std::distance (_array.begin(), it);
 }
 

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -51,7 +51,7 @@ Array::Array(plist_t node, Node* parent) : Structure(parent)
     array_fill(this, _array, _node);
 }
 
-Array::Array(const PList::Array& a) : Structure()
+Array::Array(const PList::Array& a)
 {
     _array.clear();
     _node = plist_copy(a.GetPlist());

--- a/src/Boolean.cpp
+++ b/src/Boolean.cpp
@@ -37,7 +37,7 @@ Boolean::Boolean(const PList::Boolean& b) : Node(PLIST_BOOLEAN)
     plist_set_bool_val(_node, b.GetValue());
 }
 
-Boolean& Boolean::operator=(PList::Boolean& b)
+Boolean& Boolean::operator=(const PList::Boolean& b)
 {
     plist_free(_node);
     _node = plist_copy(b.GetPlist());

--- a/src/Boolean.cpp
+++ b/src/Boolean.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/Boolean.h>
 
 namespace PList

--- a/src/Boolean.cpp
+++ b/src/Boolean.cpp
@@ -70,4 +70,4 @@ bool Boolean::GetValue() const
     return b != 0 ;
 }
 
-};
+}  // namespace PList

--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/Data.h>
 
 namespace PList

--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -38,7 +38,7 @@ Data::Data(const PList::Data& d) : Node(PLIST_DATA)
     plist_set_data_val(_node, &b[0], b.size());
 }
 
-Data& Data::operator=(PList::Data& b)
+Data& Data::operator=(const PList::Data& b)
 {
     plist_free(_node);
     _node = plist_copy(b.GetPlist());

--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -76,4 +76,4 @@ std::vector<char> Data::GetValue() const
 
 
 
-};
+}  // namespace PList

--- a/src/Date.cpp
+++ b/src/Date.cpp
@@ -38,7 +38,7 @@ Date::Date(const PList::Date& d) : Node(PLIST_DATE)
     plist_set_date_val(_node, t.tv_sec, t.tv_usec);
 }
 
-Date& Date::operator=(PList::Date& d)
+Date& Date::operator=(const PList::Date& d)
 {
     plist_free(_node);
     _node = plist_copy(d.GetPlist());

--- a/src/Date.cpp
+++ b/src/Date.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/Date.h>
 
 namespace PList

--- a/src/Date.cpp
+++ b/src/Date.cpp
@@ -73,4 +73,4 @@ timeval Date::GetValue() const
     return t;
 }
 
-};
+}  // namespace PList

--- a/src/Dictionary.cpp
+++ b/src/Dictionary.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/Dictionary.h>
 
 namespace PList

--- a/src/Dictionary.cpp
+++ b/src/Dictionary.cpp
@@ -50,7 +50,7 @@ Dictionary::Dictionary(plist_t node, Node* parent) : Structure(parent)
     dictionary_fill(this, _map, _node);
 }
 
-Dictionary::Dictionary(const PList::Dictionary& d) : Structure()
+Dictionary::Dictionary(const PList::Dictionary& d)
 {
     for (auto & it : _map)
     {

--- a/src/Dictionary.cpp
+++ b/src/Dictionary.cpp
@@ -52,10 +52,10 @@ Dictionary::Dictionary(plist_t node, Node* parent) : Structure(parent)
 
 Dictionary::Dictionary(const PList::Dictionary& d) : Structure()
 {
-    for (Dictionary::iterator it = _map.begin(); it != _map.end(); it++)
+    for (auto & it : _map)
     {
-        plist_free(it->second->GetPlist());
-        delete it->second;
+        plist_free(it.second->GetPlist());
+        delete it.second;
     }
     _map.clear();
     _node = plist_copy(d.GetPlist());
@@ -64,10 +64,10 @@ Dictionary::Dictionary(const PList::Dictionary& d) : Structure()
 
 Dictionary& Dictionary::operator=(PList::Dictionary& d)
 {
-    for (Dictionary::iterator it = _map.begin(); it != _map.end(); it++)
+    for (auto & it : _map)
     {
-        plist_free(it->second->GetPlist());
-        delete it->second;
+        plist_free(it.second->GetPlist());
+        delete it.second;
     }
     _map.clear();
     _node = plist_copy(d.GetPlist());
@@ -77,9 +77,9 @@ Dictionary& Dictionary::operator=(PList::Dictionary& d)
 
 Dictionary::~Dictionary()
 {
-    for (Dictionary::iterator it = _map.begin(); it != _map.end(); it++)
+    for (auto & it : _map)
     {
-        delete it->second;
+        delete it.second;
     }
     _map.clear();
 }
@@ -171,10 +171,10 @@ void Dictionary::Remove(const std::string& key)
 
 std::string Dictionary::GetNodeKey(Node* node)
 {
-    for (iterator it = _map.begin(); it != _map.end(); ++it)
+    for (auto & it : _map)
     {
-        if (it->second == node)
-            return it->first;
+        if (it.second == node)
+            return it.first;
     }
     return "";
 }

--- a/src/Dictionary.cpp
+++ b/src/Dictionary.cpp
@@ -179,4 +179,4 @@ std::string Dictionary::GetNodeKey(Node* node)
     return "";
 }
 
-};
+}  // namespace PList

--- a/src/Dictionary.cpp
+++ b/src/Dictionary.cpp
@@ -62,7 +62,7 @@ Dictionary::Dictionary(const PList::Dictionary& d)
     dictionary_fill(this, _map, _node);
 }
 
-Dictionary& Dictionary::operator=(PList::Dictionary& d)
+Dictionary& Dictionary::operator=(const PList::Dictionary& d)
 {
     for (auto & it : _map)
     {

--- a/src/Integer.cpp
+++ b/src/Integer.cpp
@@ -37,7 +37,7 @@ Integer::Integer(const PList::Integer& i) : Node(PLIST_UINT)
     plist_set_uint_val(_node, i.GetValue());
 }
 
-Integer& Integer::operator=(PList::Integer& i)
+Integer& Integer::operator=(const PList::Integer& i)
 {
     plist_free(_node);
     _node = plist_copy(i.GetPlist());

--- a/src/Integer.cpp
+++ b/src/Integer.cpp
@@ -70,4 +70,4 @@ uint64_t Integer::GetValue() const
     return i;
 }
 
-};
+}  // namespace PList

--- a/src/Integer.cpp
+++ b/src/Integer.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/Integer.h>
 
 namespace PList

--- a/src/Key.cpp
+++ b/src/Key.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/Key.h>
 
 namespace PList

--- a/src/Key.cpp
+++ b/src/Key.cpp
@@ -37,7 +37,7 @@ Key::Key(const PList::Key& k) : Node(PLIST_UINT)
     plist_set_key_val(_node, k.GetValue().c_str());
 }
 
-Key& Key::operator=(PList::Key& k)
+Key& Key::operator=(const PList::Key& k)
 {
     plist_free(_node);
     _node = plist_copy(k.GetPlist());

--- a/src/Key.cpp
+++ b/src/Key.cpp
@@ -77,4 +77,4 @@ std::string Key::GetValue() const
     return ret;
 }
 
-};
+}  // namespace PList

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/Node.h>
 #include <plist/Structure.h>
 #include <plist/Dictionary.h>

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -163,4 +163,4 @@ Node* Node::FromPlist(plist_t node, Node* parent)
     return ret;
 }
 
-};
+}  // namespace PList

--- a/src/Real.cpp
+++ b/src/Real.cpp
@@ -37,7 +37,7 @@ Real::Real(const PList::Real& d) : Node(PLIST_UINT)
     plist_set_real_val(_node, d.GetValue());
 }
 
-Real& Real::operator=(PList::Real& d)
+Real& Real::operator=(const PList::Real& d)
 {
     plist_free(_node);
     _node = plist_copy(d.GetPlist());

--- a/src/Real.cpp
+++ b/src/Real.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/Real.h>
 
 namespace PList

--- a/src/Real.cpp
+++ b/src/Real.cpp
@@ -70,4 +70,4 @@ double Real::GetValue() const
     return d;
 }
 
-};
+}  // namespace PList

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/String.h>
 
 namespace PList

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -77,4 +77,4 @@ std::string String::GetValue() const
     return ret;
 }
 
-};
+}  // namespace PList

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -37,7 +37,7 @@ String::String(const PList::String& s) : Node(PLIST_UINT)
     plist_set_string_val(_node, s.GetValue().c_str());
 }
 
-String& String::operator=(PList::String& s)
+String& String::operator=(const PList::String& s)
 {
     plist_free(_node);
     _node = plist_copy(s.GetPlist());

--- a/src/Structure.cpp
+++ b/src/Structure.cpp
@@ -119,5 +119,5 @@ Structure* Structure::FromBin(const std::vector<char>& bin)
 
 }
 
-};
+}  // namespace PList
 

--- a/src/Structure.cpp
+++ b/src/Structure.cpp
@@ -78,7 +78,7 @@ void Structure::UpdateNodeParent(Node* node)
         plist_type type = plist_get_node_type(node->_parent);
         if (PLIST_ARRAY ==type || PLIST_DICT == type )
         {
-            auto* s = static_cast<Structure*>(node->_parent);
+            auto* s = dynamic_cast<Structure*>(node->_parent);
             s->Remove(node);
         }
     }
@@ -92,7 +92,7 @@ static Structure* ImportStruct(plist_t root)
 
     if (PLIST_ARRAY == type || PLIST_DICT == type)
     {
-        ret = static_cast<Structure*>(Node::FromPlist(root));
+        ret = dynamic_cast<Structure*>(Node::FromPlist(root));
     }
     else
     {

--- a/src/Structure.cpp
+++ b/src/Structure.cpp
@@ -78,7 +78,7 @@ void Structure::UpdateNodeParent(Node* node)
         plist_type type = plist_get_node_type(node->_parent);
         if (PLIST_ARRAY ==type || PLIST_DICT == type )
         {
-            Structure* s = static_cast<Structure*>(node->_parent);
+            auto* s = static_cast<Structure*>(node->_parent);
             s->Remove(node);
         }
     }

--- a/src/Structure.cpp
+++ b/src/Structure.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/Structure.h>
 
 namespace PList

--- a/src/Uid.cpp
+++ b/src/Uid.cpp
@@ -37,7 +37,7 @@ Uid::Uid(const PList::Uid& i) : Node(PLIST_UID)
     plist_set_uid_val(_node, i.GetValue());
 }
 
-Uid& Uid::operator=(PList::Uid& i)
+Uid& Uid::operator=(const PList::Uid& i)
 {
     plist_free(_node);
     _node = plist_copy(i.GetPlist());

--- a/src/Uid.cpp
+++ b/src/Uid.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <plist/Uid.h>
 
 namespace PList

--- a/src/Uid.cpp
+++ b/src/Uid.cpp
@@ -70,4 +70,4 @@ uint64_t Uid::GetValue() const
     return i;
 }
 
-};
+}  // namespace PList


### PR DESCRIPTION
Requires a C++11 compiler but not a C++11 libc++. Meaning something like uClibc++ still works. I can remove those commits if requested.