### PR TITLE
time64/ctime64_r: localtime64_r can fail

### DIFF
--- a/src/time64.c
+++ b/src/time64.c
@@ -806,7 +806,9 @@ char *asctime64_r( const struct TM* date, char *result ) {
 char *ctime64_r( const Time64_T* time, char* result ) {
     struct TM date;
 
-    localtime64_r( time, &date );
+    if (!localtime64_r( time, &date ))
+        return NULL;
+
     return asctime64_r( &date, result );
 }
 


### PR DESCRIPTION
In ctime64_r, the call to localtime64_r can fail.  If we don't check for
this and then call asctime64_r, the results are garbage.

Signed-off-by: Derrick Lyndon Pallas <derrick@pallas.us>