### PR TITLE
fix a typo in plistutil manpage

### DIFF
--- a/docs/plistutil.1
+++ b/docs/plistutil.1
@@ -7,7 +7,7 @@ plistutil \- Convert a plist FILE from binary to XML format or vice-versa
 [-i FILE]
 [-o FILE]
 .SH DESCRIPTION
-plistutil allows to convert a file in Property List format from binary to XML format or vice-versa.
+plistutil allows one to convert a file in Property List format from binary to XML format or vice-versa.
 .SH OPTIONS
 .TP
 .B \-i, \-\-infile FILE


### PR DESCRIPTION
The correct form in English seems to be “allows one to” (and not just “allows to”). Here's a small PR to fix that.