### PR TITLE
clang-tidy: replace free with delete

### DIFF
--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -70,7 +70,7 @@ std::vector<char> Data::GetValue() const
     uint64_t length = 0;
     plist_get_data_val(_node, &buff, &length);
     std::vector<char> ret(buff, buff + length);
-    free(buff);
+    delete buff;
     return ret;
 }
 

--- a/src/Dictionary.cpp
+++ b/src/Dictionary.cpp
@@ -39,7 +39,7 @@ static void dictionary_fill(Dictionary *_this, std::map<std::string,Node*> &map,
         plist_dict_next_item(node, it, &key, &subnode);
         if (key && subnode)
             map[std::string(key)] = Node::FromPlist(subnode, _this);
-        free(key);
+        delete key;
     } while (subnode);
     free(it);
 }
@@ -156,7 +156,7 @@ void Dictionary::Remove(Node* node)
         plist_dict_get_item_key(node->GetPlist(), &key);
         plist_dict_remove_item(_node, key);
         std::string skey = key;
-        free(key);
+        delete key;
         _map.erase(skey);
         delete node;
     }

--- a/src/Key.cpp
+++ b/src/Key.cpp
@@ -67,13 +67,8 @@ std::string Key::GetValue() const
 {
     char* s = NULL;
     plist_get_key_val(_node, &s);
-    std::string ret;
-    if (s) {
-        ret = s;
-        free(s);
-    } else {
-        ret = "";
-    }
+    std::string ret = s ? s : "";
+    delete s;
     return ret;
 }
 

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -67,13 +67,8 @@ std::string String::GetValue() const
 {
     char* s = NULL;
     plist_get_string_val(_node, &s);
-    std::string ret;
-    if (s) {
-        ret = s;
-        free(s);
-    } else {
-        ret = "";
-    }
+    std::string ret = s ? s : "";
+    delete s;
     return ret;
 }
 

--- a/src/Structure.cpp
+++ b/src/Structure.cpp
@@ -56,7 +56,7 @@ std::string Structure::ToXml() const
     uint32_t length = 0;
     plist_to_xml(_node, &xml, &length);
     std::string ret(xml, xml+length);
-    free(xml);
+    delete xml;
     return ret;
 }
 
@@ -66,7 +66,7 @@ std::vector<char> Structure::ToBin() const
     uint32_t length = 0;
     plist_to_bin(_node, &bin, &length);
     std::vector<char> ret(bin, bin+length);
-    free(bin);
+    delete bin;
     return ret;
 }
 


### PR DESCRIPTION
It's the C++ way. It also avoids having to check for NULL.

Found with cppcoreguidelines-owning-memory

Signed-off-by: Rosen Penev <rosenp@gmail.com>