### PR TITLE
clang-tidy: remove casts to the same type

### DIFF
--- a/src/plist.c
+++ b/src/plist.c
@@ -395,7 +395,7 @@ static plist_t plist_copy_node(node_t *node)
             break;
         case PLIST_KEY:
         case PLIST_STRING:
-            newdata->strval = strdup((char *) data->strval);
+            newdata->strval = strdup(data->strval);
             break;
         case PLIST_ARRAY:
             if (data->hashtable) {

--- a/src/xplist.c
+++ b/src/xplist.c
@@ -1142,7 +1142,7 @@ static void node_from_xml(parse_ctx ctx, plist_t *plist)
                             }
                             str++;
                         }
-                        data->intval = strtoull((char*)str, NULL, 0);
+                        data->intval = strtoull(str, NULL, 0);
                         if (is_negative || (data->intval <= INT64_MAX)) {
                             uint64_t v = data->intval;
                             if (is_negative) {


### PR DESCRIPTION
Found with google-readability-casting

Signed-off-by: Rosen Penev <rosenp@gmail.com>