### PR TITLE
Fixed bug in array_fill

### DIFF
--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -32,7 +32,7 @@ Array::Array(Node* parent) : Structure(PLIST_ARRAY, parent)
     _array.clear();
 }
 
-static void array_fill(Array *_this, std::vector<Node*> array, plist_t node)
+static void array_fill(Array *_this, std::vector<Node*> &array, plist_t node)
 {
     plist_array_iter iter = NULL;
     plist_array_new_iter(node, &iter);


### PR DESCRIPTION
Bug: when creating a new Array object (for example through PList::Node::FromPlist(plist_t node) ), the array_fill function is called from Array() constructor in line 51. It seems that the intended way of calling array_fill() is to pass the _array object by reference, however it is actually passed by value. Thus the changes to the array object made by array_fill() are discarded when the function returns.
Fix: pass _array by reference to keep the changes