### PR TITLE
Fix for LibTool compalation and Python 3 libintl

### DIFF
--- a/cython/Makefile.am
+++ b/cython/Makefile.am
@@ -39,7 +39,7 @@ plist_la_CFLAGS = \
 	-Wno-implicit-function-declaration \
 	-fvisibility=default
 
-plist_la_LDFLAGS = -module -avoid-version $(PYTHON_LIBS) $(AM_LDFLAGS) -no-undefined
+plist_la_LDFLAGS = -module -avoid-version $(PYTHON_LIBS) $(AM_LDFLAGS) -shared -export-dynamic
 plist_la_LIBADD = $(top_builddir)/src/libplist-2.0.la
 
 plist.c: plist.pyx $(PXDINCLUDES) $(PXIINCLUDES)


### PR DESCRIPTION
On Python 3.9 `libpython` no longer is linkable as a static library
due to the fact that `libpython` now depends on `libintl`.  This would
mean we would have to import `libintl` to create a fully linked .la

It is better to be explicit that we are building a .so (really a .dylib
but autotools uses linux file conventions) that doesn't have to be fully
resolved.

Resolves #196 