### PR TITLE
Get rid of casting a ptr to a 32 bit value

### DIFF
--- a/src/bplist.c
+++ b/src/bplist.c
@@ -751,8 +751,8 @@ static plist_t parse_bin_node_at_index(struct bplist_data *bplist, uint32_t node
     /* recursion check */
     if (bplist->level > 0) {
         for (i = bplist->level-1; i >= 0; i--) {
-            uint32_t node_i = (uint32_t)(uintptr_t)ptr_array_index(bplist->used_indexes, i);
-            uint32_t node_level = (uint32_t)(uintptr_t)ptr_array_index(bplist->used_indexes, bplist->level);
+            void *node_i = ptr_array_index(bplist->used_indexes, i);
+            void *node_level = ptr_array_index(bplist->used_indexes, bplist->level);
             if (node_i == node_level) {
                 PLIST_BIN_ERR("recursion detected in binary plist\n");
                 return NULL;


### PR DESCRIPTION
This causes a warning if `-Wbad-function-cast` is enabled on a build.

Maybe I'm missing something because I can't see why the casts were there in the first place? This passes all the tests.