### PR TITLE
+ plist_free_memory api

### DIFF
--- a/include/plist/plist.h
+++ b/include/plist/plist.h
@@ -212,6 +212,13 @@ extern "C"
     void plist_free(plist_t plist);
 
     /**
+     * Free memory using heap manager of libplist
+     *
+     * @param pointer to the memory to free
+     */
+    void plist_free_memory(void* ptr);
+
+    /**
      * Return a copy of passed node and it's children
      *
      * @param node the plist to copy
@@ -646,13 +653,6 @@ extern "C"
     void plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length);
 
     /**
-     * Frees the memory allocated by plist_to_xml().
-     *
-     * @param plist_xml The buffer allocated by plist_to_xml().
-     */
-    void plist_to_xml_free(char *plist_xml);
-
-    /**
      * Export the #plist_t structure to binary format.
      *
      * @param plist the root node to export
@@ -661,13 +661,6 @@ extern "C"
      * @param length a pointer to an uint32_t variable. Represents the length of the allocated buffer.
      */
     void plist_to_bin(plist_t plist, char **plist_bin, uint32_t * length);
-
-    /**
-     * Frees the memory allocated by plist_to_bin().
-     *
-     * @param plist_bin The buffer allocated by plist_to_bin().
-     */
-    void plist_to_bin_free(char *plist_bin);
 
     /**
      * Import the #plist_t structure from XML format.

--- a/src/plist.c
+++ b/src/plist.c
@@ -382,6 +382,14 @@ PLIST_API void plist_free(plist_t plist)
     }
 }
 
+PLIST_API plist_free_memory(void* ptr)
+{
+    if (ptr)
+    {
+        free(ptr);
+    }
+}
+
 static plist_t plist_copy_node(node_t *node)
 {
     plist_type node_type = PLIST_NONE;

--- a/src/plist.c
+++ b/src/plist.c
@@ -382,7 +382,7 @@ PLIST_API void plist_free(plist_t plist)
     }
 }
 
-PLIST_API plist_free_memory(void* ptr)
+PLIST_API void plist_free_memory(void* ptr)
 {
     if (ptr)
     {


### PR DESCRIPTION
**plist_free_memory** will allow callers to use heap manager of libplist to free memory allocated by libplist.
Currently there are 5 apis that are able to allocate memory:
* plist_get_key_val
* plist_get_string_val
* plist_get_data_val
* plist_to_xml
* plist_to_bin

Instead of having 5 identical freeing apis, i would like to offer one generic one.