### PR TITLE
bplist: Fix strict aliasing violations

### DIFF
--- a/src/bplist.c
+++ b/src/bplist.c
@@ -998,18 +998,24 @@ static void write_real(bytearray_t * bplist, double val)
     buff[7] = BPLIST_REAL | Log2(size);
     if (size == sizeof(float)) {
         float floatval = (float)val;
-        *(uint32_t*)(buff+8) = float_bswap32(*(uint32_t*)&floatval);
+        uint32_t intval;
+        memcpy(&intval, &floatval, sizeof(float));
+        *(uint32_t*)(buff+8) = float_bswap32(intval);
     } else {
-        *(uint64_t*)(buff+8) = float_bswap64(*(uint64_t*)&val);
+        uint64_t intval;
+        memcpy(&intval, &val, sizeof(double));
+        *(uint64_t*)(buff+8) = float_bswap64(intval);
     }
     byte_array_append(bplist, buff+7, size+1);
 }
 
 static void write_date(bytearray_t * bplist, double val)
 {
+    uint64_t intval;
+    memcpy(&intval, &val, sizeof(double));
     uint8_t buff[16];
     buff[7] = BPLIST_DATE | 3;
-    *(uint64_t*)(buff+8) = float_bswap64(*(uint64_t*)&val);
+    *(uint64_t*)(buff+8) = float_bswap64(intval);
     byte_array_append(bplist, buff+7, 9);
 }
 


### PR DESCRIPTION
Casting a float pointer to an int pointer is a strict aliasing violation (`-Wstrict-aliasing`) and is undefined behaviour (although, it did not seem to cause any issues in practice here).

An optimising compiler should elide the `memcpy`s added by this commit.