### PR TITLE
add PLIST_OPT_NONE

### DIFF
--- a/include/plist/plist.h
+++ b/include/plist/plist.h
@@ -157,6 +157,7 @@ extern "C"
      */
     typedef enum
     {
+        PLIST_OPT_NONE   = 0,
         PLIST_OPT_COMPACT   = 1 << 0, /**< Use a compact representation (non-prettified). Only valid for #PLIST_FORMAT_JSON and #PLIST_FORMAT_OSTEP. */
         PLIST_OPT_PARTIAL_DATA = 1 << 1, /**< Print 24 bytes maximum of #PLIST_DATA values. If the data is longer than 24 bytes,  the first 16 and last 8 bytes will be written. Only valid for #PLIST_FORMAT_PRINT. */
         PLIST_OPT_NO_NEWLINE = 1 << 2, /**< Do not print a final newline character. Only valid for #PLIST_FORMAT_PRINT, #PLIST_FORMAT_LIMD, and #PLIST_FORMAT_PLUTIL. */


### PR DESCRIPTION
Add enum val for when no extra functionality is needed.
When trying to write plist to file using the function:
```
plist_write_to_file(p_someplist, somefilename, PLIST_FORMAT_XML, 0)
```
The C++ compiler will complain that 0 (`int`) is not a valid `plist_write_options_t`.
Instead it should be written as something like this:
```
plist_write_to_file(p_someplist, somefilename, PLIST_FORMAT_XML, PLIST_OPT_NONE)
```
