### PR TITLE
fix MinGW compilation

### DIFF
--- a/include/plist/plist.h
+++ b/include/plist/plist.h
@@ -44,6 +44,20 @@ extern "C"
 #include <stdint.h>
 #endif
 
+#ifdef _WIN32
+  #ifdef DLL_EXPORT
+    #define PLIST_API __declspec( dllexport )
+  #else
+    #define PLIST_API
+  #endif
+#else
+  #ifdef HAVE_FVISIBILITY
+    #define PLIST_API __attribute__((visibility("default")))
+  #else
+    #define PLIST_API
+  #endif
+#endif
+
 /*{{{ deprecation macros */
 #ifdef __llvm__
   #if defined(__has_extension)
@@ -180,7 +194,7 @@ extern "C"
      * @return the created plist
      * @sa #plist_type
      */
-    plist_t plist_new_dict(void);
+    PLIST_API plist_t plist_new_dict(void);
 
     /**
      * Create a new root plist_t type #PLIST_ARRAY
@@ -188,7 +202,7 @@ extern "C"
      * @return the created plist
      * @sa #plist_type
      */
-    plist_t plist_new_array(void);
+    PLIST_API plist_t plist_new_array(void);
 
     /**
      * Create a new plist_t type #PLIST_STRING
@@ -197,7 +211,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_string(const char *val);
+    PLIST_API plist_t plist_new_string(const char *val);
 
     /**
      * Create a new plist_t type #PLIST_BOOLEAN
@@ -206,7 +220,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_bool(uint8_t val);
+    PLIST_API plist_t plist_new_bool(uint8_t val);
 
     /**
      * Create a new plist_t type #PLIST_INT with an unsigned integer value
@@ -217,7 +231,7 @@ extern "C"
      * @note The value is always stored as uint64_t internally.
      *    Use #plist_get_uint_val or #plist_get_int_val to get the unsigned or signed value.
      */
-    plist_t plist_new_uint(uint64_t val);
+    PLIST_API plist_t plist_new_uint(uint64_t val);
 
     /**
      * Create a new plist_t type #PLIST_INT with a signed integer value
@@ -228,7 +242,7 @@ extern "C"
      * @note The value is always stored as uint64_t internally.
      *    Use #plist_get_uint_val or #plist_get_int_val to get the unsigned or signed value.
      */
-    plist_t plist_new_int(int64_t val);
+    PLIST_API plist_t plist_new_int(int64_t val);
 
     /**
      * Create a new plist_t type #PLIST_REAL
@@ -237,7 +251,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_real(double val);
+    PLIST_API plist_t plist_new_real(double val);
 
     /**
      * Create a new plist_t type #PLIST_DATA
@@ -247,7 +261,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_data(const char *val, uint64_t length);
+    PLIST_API plist_t plist_new_data(const char *val, uint64_t length);
 
     /**
      * Create a new plist_t type #PLIST_DATE
@@ -257,7 +271,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_date(int32_t sec, int32_t usec);
+    PLIST_API plist_t plist_new_date(int32_t sec, int32_t usec);
 
     /**
      * Create a new plist_t type #PLIST_UID
@@ -266,7 +280,7 @@ extern "C"
      * @return the created item
      * @sa #plist_type
      */
-    plist_t plist_new_uid(uint64_t val);
+    PLIST_API plist_t plist_new_uid(uint64_t val);
 
     /**
      * Create a new plist_t type #PLIST_NULL
@@ -275,14 +289,14 @@ extern "C"
      * @note This type is not valid for all formats, e.g. the XML format
      *     does not support it.
      */
-    plist_t plist_new_null(void);
+    PLIST_API plist_t plist_new_null(void);
 
     /**
      * Destruct a plist_t node and all its children recursively
      *
      * @param plist the plist to free
      */
-    void plist_free(plist_t plist);
+    PLIST_API void plist_free(plist_t plist);
 
     /**
      * Return a copy of passed node and it's children
@@ -290,7 +304,7 @@ extern "C"
      * @param node the plist to copy
      * @return copied plist
      */
-    plist_t plist_copy(plist_t node);
+    PLIST_API plist_t plist_copy(plist_t node);
 
 
     /********************************************
@@ -305,7 +319,7 @@ extern "C"
      * @param node the node of type #PLIST_ARRAY
      * @return size of the #PLIST_ARRAY node
      */
-    uint32_t plist_array_get_size(plist_t node);
+    PLIST_API uint32_t plist_array_get_size(plist_t node);
 
     /**
      * Get the nth item in a #PLIST_ARRAY node.
@@ -314,7 +328,7 @@ extern "C"
      * @param n the index of the item to get. Range is [0, array_size[
      * @return the nth item or NULL if node is not of type #PLIST_ARRAY
      */
-    plist_t plist_array_get_item(plist_t node, uint32_t n);
+    PLIST_API plist_t plist_array_get_item(plist_t node, uint32_t n);
 
     /**
      * Get the index of an item. item must be a member of a #PLIST_ARRAY node.
@@ -322,7 +336,7 @@ extern "C"
      * @param node the node
      * @return the node index or UINT_MAX if node index can't be determined
      */
-    uint32_t plist_array_get_item_index(plist_t node);
+    PLIST_API uint32_t plist_array_get_item_index(plist_t node);
 
     /**
      * Set the nth item in a #PLIST_ARRAY node.
@@ -332,7 +346,7 @@ extern "C"
      * @param item the new item at index n. The array is responsible for freeing item when it is no longer needed.
      * @param n the index of the item to get. Range is [0, array_size[. Assert if n is not in range.
      */
-    void plist_array_set_item(plist_t node, plist_t item, uint32_t n);
+    PLIST_API void plist_array_set_item(plist_t node, plist_t item, uint32_t n);
 
     /**
      * Append a new item at the end of a #PLIST_ARRAY node.
@@ -340,7 +354,7 @@ extern "C"
      * @param node the node of type #PLIST_ARRAY
      * @param item the new item. The array is responsible for freeing item when it is no longer needed.
      */
-    void plist_array_append_item(plist_t node, plist_t item);
+    PLIST_API void plist_array_append_item(plist_t node, plist_t item);
 
     /**
      * Insert a new item at position n in a #PLIST_ARRAY node.
@@ -349,7 +363,7 @@ extern "C"
      * @param item the new item to insert. The array is responsible for freeing item when it is no longer needed.
      * @param n The position at which the node will be stored. Range is [0, array_size[. Assert if n is not in range.
      */
-    void plist_array_insert_item(plist_t node, plist_t item, uint32_t n);
+    PLIST_API void plist_array_insert_item(plist_t node, plist_t item, uint32_t n);
 
     /**
      * Remove an existing position in a #PLIST_ARRAY node.
@@ -358,7 +372,7 @@ extern "C"
      * @param node the node of type #PLIST_ARRAY
      * @param n The position to remove. Range is [0, array_size[. Assert if n is not in range.
      */
-    void plist_array_remove_item(plist_t node, uint32_t n);
+    PLIST_API void plist_array_remove_item(plist_t node, uint32_t n);
 
     /**
      * Remove a node that is a child node of a #PLIST_ARRAY node.
@@ -366,7 +380,7 @@ extern "C"
      *
      * @param node The node to be removed from its #PLIST_ARRAY parent.
      */
-    void plist_array_item_remove(plist_t node);
+    PLIST_API void plist_array_item_remove(plist_t node);
 
     /**
      * Create an iterator of a #PLIST_ARRAY node.
@@ -375,7 +389,7 @@ extern "C"
      * @param node The node of type #PLIST_ARRAY
      * @param iter Location to store the iterator for the array.
      */
-    void plist_array_new_iter(plist_t node, plist_array_iter *iter);
+    PLIST_API void plist_array_new_iter(plist_t node, plist_array_iter *iter);
 
     /**
      * Increment iterator of a #PLIST_ARRAY node.
@@ -386,7 +400,7 @@ extern "C"
      *          returned item. Will be set to NULL when no more items are left
      *          to iterate.
      */
-    void plist_array_next_item(plist_t node, plist_array_iter iter, plist_t *item);
+    PLIST_API void plist_array_next_item(plist_t node, plist_array_iter iter, plist_t *item);
 
 
     /********************************************
@@ -401,7 +415,7 @@ extern "C"
      * @param node the node of type #PLIST_DICT
      * @return size of the #PLIST_DICT node
      */
-    uint32_t plist_dict_get_size(plist_t node);
+    PLIST_API uint32_t plist_dict_get_size(plist_t node);
 
     /**
      * Create an iterator of a #PLIST_DICT node.
@@ -410,7 +424,7 @@ extern "C"
      * @param node The node of type #PLIST_DICT.
      * @param iter Location to store the iterator for the dictionary.
      */
-    void plist_dict_new_iter(plist_t node, plist_dict_iter *iter);
+    PLIST_API void plist_dict_new_iter(plist_t node, plist_dict_iter *iter);
 
     /**
      * Increment iterator of a #PLIST_DICT node.
@@ -423,7 +437,7 @@ extern "C"
      *		free the returned value. Will be set to NULL when no more
      *		key/value pairs are left to iterate.
      */
-    void plist_dict_next_item(plist_t node, plist_dict_iter iter, char **key, plist_t *val);
+    PLIST_API void plist_dict_next_item(plist_t node, plist_dict_iter iter, char **key, plist_t *val);
 
     /**
      * Get key associated key to an item. Item must be member of a dictionary.
@@ -431,7 +445,7 @@ extern "C"
      * @param node the item
      * @param key a location to store the key. The caller is responsible for freeing the returned string.
      */
-    void plist_dict_get_item_key(plist_t node, char **key);
+    PLIST_API void plist_dict_get_item_key(plist_t node, char **key);
 
     /**
      * Get the nth item in a #PLIST_DICT node.
@@ -441,7 +455,7 @@ extern "C"
      * @return the item or NULL if node is not of type #PLIST_DICT. The caller should not free
      *		the returned node.
      */
-    plist_t plist_dict_get_item(plist_t node, const char* key);
+    PLIST_API plist_t plist_dict_get_item(plist_t node, const char* key);
 
     /**
      * Get key node associated to an item. Item must be member of a dictionary.
@@ -449,7 +463,7 @@ extern "C"
      * @param node the item
      * @return the key node of the given item, or NULL.
      */
-    plist_t plist_dict_item_get_key(plist_t node);
+    PLIST_API plist_t plist_dict_item_get_key(plist_t node);
 
     /**
      * Set item identified by key in a #PLIST_DICT node.
@@ -460,7 +474,7 @@ extern "C"
      * @param item the new item associated to key
      * @param key the identifier of the item to set.
      */
-    void plist_dict_set_item(plist_t node, const char* key, plist_t item);
+    PLIST_API void plist_dict_set_item(plist_t node, const char* key, plist_t item);
 
     /**
      * Remove an existing position in a #PLIST_DICT node.
@@ -469,7 +483,7 @@ extern "C"
      * @param node the node of type #PLIST_DICT
      * @param key The identifier of the item to remove. Assert if identifier is not present.
      */
-    void plist_dict_remove_item(plist_t node, const char* key);
+    PLIST_API void plist_dict_remove_item(plist_t node, const char* key);
 
     /**
      * Merge a dictionary into another. This will add all key/value pairs
@@ -479,7 +493,7 @@ extern "C"
      * @param target pointer to an existing node of type #PLIST_DICT
      * @param source node of type #PLIST_DICT that should be merged into target
      */
-    void plist_dict_merge(plist_t *target, plist_t source);
+    PLIST_API void plist_dict_merge(plist_t *target, plist_t source);
 
 
     /********************************************
@@ -493,7 +507,7 @@ extern "C"
      *
      * @param node the parent (NULL if node is root)
      */
-    plist_t plist_get_parent(plist_t node);
+    PLIST_API plist_t plist_get_parent(plist_t node);
 
     /**
      * Get the #plist_type of a node.
@@ -501,7 +515,7 @@ extern "C"
      * @param node the node
      * @return the type of the node
      */
-    plist_type plist_get_node_type(plist_t node);
+    PLIST_API plist_type plist_get_node_type(plist_t node);
 
     /**
      * Get the value of a #PLIST_KEY node.
@@ -512,7 +526,7 @@ extern "C"
      *            caller is responsible for freeing it.
      * @note Use plist_mem_free() to free the allocated memory.
      */
-    void plist_get_key_val(plist_t node, char **val);
+    PLIST_API void plist_get_key_val(plist_t node, char **val);
 
     /**
      * Get the value of a #PLIST_STRING node.
@@ -523,7 +537,7 @@ extern "C"
      *            caller is responsible for freeing it. Data is UTF-8 encoded.
      * @note Use plist_mem_free() to free the allocated memory.
      */
-    void plist_get_string_val(plist_t node, char **val);
+    PLIST_API void plist_get_string_val(plist_t node, char **val);
 
     /**
      * Get a pointer to the buffer of a #PLIST_STRING node.
@@ -536,7 +550,7 @@ extern "C"
      *
      * @return Pointer to the NULL-terminated buffer.
      */
-    const char* plist_get_string_ptr(plist_t node, uint64_t* length);
+    PLIST_API const char* plist_get_string_ptr(plist_t node, uint64_t* length);
 
     /**
      * Get the value of a #PLIST_BOOLEAN node.
@@ -545,7 +559,7 @@ extern "C"
      * @param node the node
      * @param val a pointer to a uint8_t variable.
      */
-    void plist_get_bool_val(plist_t node, uint8_t * val);
+    PLIST_API void plist_get_bool_val(plist_t node, uint8_t * val);
 
     /**
      * Get the unsigned integer value of a #PLIST_INT node.
@@ -554,7 +568,7 @@ extern "C"
      * @param node the node
      * @param val a pointer to a uint64_t variable.
      */
-    void plist_get_uint_val(plist_t node, uint64_t * val);
+    PLIST_API void plist_get_uint_val(plist_t node, uint64_t * val);
 
     /**
      * Get the signed integer value of a #PLIST_INT node.
@@ -563,7 +577,7 @@ extern "C"
      * @param node the node
      * @param val a pointer to a int64_t variable.
      */
-    void plist_get_int_val(plist_t node, int64_t * val);
+    PLIST_API void plist_get_int_val(plist_t node, int64_t * val);
 
     /**
      * Get the value of a #PLIST_REAL node.
@@ -572,7 +586,7 @@ extern "C"
      * @param node the node
      * @param val a pointer to a double variable.
      */
-    void plist_get_real_val(plist_t node, double *val);
+    PLIST_API void plist_get_real_val(plist_t node, double *val);
 
     /**
      * Get the value of a #PLIST_DATA node.
@@ -584,7 +598,7 @@ extern "C"
      * @param length the length of the buffer
      * @note Use plist_mem_free() to free the allocated memory.
      */
-    void plist_get_data_val(plist_t node, char **val, uint64_t * length);
+    PLIST_API void plist_get_data_val(plist_t node, char **val, uint64_t * length);
 
     /**
      * Get a pointer to the data buffer of a #PLIST_DATA node.
@@ -597,7 +611,7 @@ extern "C"
      *
      * @return Pointer to the buffer
      */
-    const char* plist_get_data_ptr(plist_t node, uint64_t* length);
+    PLIST_API const char* plist_get_data_ptr(plist_t node, uint64_t* length);
 
     /**
      * Get the value of a #PLIST_DATE node.
@@ -607,7 +621,7 @@ extern "C"
      * @param sec a pointer to an int32_t variable. Represents the number of seconds since 01/01/2001.
      * @param usec a pointer to an int32_t variable. Represents the number of microseconds
      */
-    void plist_get_date_val(plist_t node, int32_t * sec, int32_t * usec);
+    PLIST_API void plist_get_date_val(plist_t node, int32_t * sec, int32_t * usec);
 
     /**
      * Get the value of a #PLIST_UID node.
@@ -616,7 +630,7 @@ extern "C"
      * @param node the node
      * @param val a pointer to a uint64_t variable.
      */
-    void plist_get_uid_val(plist_t node, uint64_t * val);
+    PLIST_API void plist_get_uid_val(plist_t node, uint64_t * val);
 
 
     /********************************************
@@ -632,7 +646,7 @@ extern "C"
      * @param node the node
      * @param val the key value
      */
-    void plist_set_key_val(plist_t node, const char *val);
+    PLIST_API void plist_set_key_val(plist_t node, const char *val);
 
     /**
      * Set the value of a node.
@@ -642,7 +656,7 @@ extern "C"
      * @param val the string value. The string is copied when set and will be
      *		freed by the node.
      */
-    void plist_set_string_val(plist_t node, const char *val);
+    PLIST_API void plist_set_string_val(plist_t node, const char *val);
 
     /**
      * Set the value of a node.
@@ -651,7 +665,7 @@ extern "C"
      * @param node the node
      * @param val the boolean value
      */
-    void plist_set_bool_val(plist_t node, uint8_t val);
+    PLIST_API void plist_set_bool_val(plist_t node, uint8_t val);
 
     /**
      * Set the value of a node.
@@ -660,7 +674,7 @@ extern "C"
      * @param node the node
      * @param val the unsigned integer value
      */
-    void plist_set_uint_val(plist_t node, uint64_t val);
+    PLIST_API void plist_set_uint_val(plist_t node, uint64_t val);
 
     /**
      * Set the value of a node.
@@ -669,7 +683,7 @@ extern "C"
      * @param node the node
      * @param val the signed integer value
      */
-    void plist_set_int_val(plist_t node, int64_t val);
+    PLIST_API void plist_set_int_val(plist_t node, int64_t val);
 
     /**
      * Set the value of a node.
@@ -678,7 +692,7 @@ extern "C"
      * @param node the node
      * @param val the real value
      */
-    void plist_set_real_val(plist_t node, double val);
+    PLIST_API void plist_set_real_val(plist_t node, double val);
 
     /**
      * Set the value of a node.
@@ -689,7 +703,7 @@ extern "C"
      *		be freed by the node.
      * @param length the length of the buffer
      */
-    void plist_set_data_val(plist_t node, const char *val, uint64_t length);
+    PLIST_API void plist_set_data_val(plist_t node, const char *val, uint64_t length);
 
     /**
      * Set the value of a node.
@@ -699,7 +713,7 @@ extern "C"
      * @param sec the number of seconds since 01/01/2001
      * @param usec the number of microseconds
      */
-    void plist_set_date_val(plist_t node, int32_t sec, int32_t usec);
+    PLIST_API void plist_set_date_val(plist_t node, int32_t sec, int32_t usec);
 
     /**
      * Set the value of a node.
@@ -708,7 +722,7 @@ extern "C"
      * @param node the node
      * @param val the unsigned integer value
      */
-    void plist_set_uid_val(plist_t node, uint64_t val);
+    PLIST_API void plist_set_uid_val(plist_t node, uint64_t val);
 
 
     /********************************************
@@ -727,7 +741,7 @@ extern "C"
      * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure
      * @note Use plist_mem_free() to free the allocated memory.
      */
-    plist_err_t plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length);
+    PLIST_API plist_err_t plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length);
 
     /**
      * Export the #plist_t structure to binary format.
@@ -739,7 +753,7 @@ extern "C"
      * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure
      * @note Use plist_mem_free() to free the allocated memory.
      */
-    plist_err_t plist_to_bin(plist_t plist, char **plist_bin, uint32_t * length);
+    PLIST_API plist_err_t plist_to_bin(plist_t plist, char **plist_bin, uint32_t * length);
 
     /**
      * Export the #plist_t structure to JSON format.
@@ -752,7 +766,7 @@ extern "C"
      * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure
      * @note Use plist_mem_free() to free the allocated memory.
      */
-    plist_err_t plist_to_json(plist_t plist, char **plist_json, uint32_t* length, int prettify);
+    PLIST_API plist_err_t plist_to_json(plist_t plist, char **plist_json, uint32_t* length, int prettify);
 
     /**
      * Export the #plist_t structure to OpenStep format.
@@ -765,7 +779,7 @@ extern "C"
      * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure
      * @note Use plist_mem_free() to free the allocated memory.
      */
-    plist_err_t plist_to_openstep(plist_t plist, char **plist_openstep, uint32_t* length, int prettify);
+    PLIST_API plist_err_t plist_to_openstep(plist_t plist, char **plist_openstep, uint32_t* length, int prettify);
 
 
     /**
@@ -776,7 +790,7 @@ extern "C"
      * @param plist a pointer to the imported plist.
      * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure
      */
-    plist_err_t plist_from_xml(const char *plist_xml, uint32_t length, plist_t * plist);
+    PLIST_API plist_err_t plist_from_xml(const char *plist_xml, uint32_t length, plist_t * plist);
 
     /**
      * Import the #plist_t structure from binary format.
@@ -786,7 +800,7 @@ extern "C"
      * @param plist a pointer to the imported plist.
      * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure
      */
-    plist_err_t plist_from_bin(const char *plist_bin, uint32_t length, plist_t * plist);
+    PLIST_API plist_err_t plist_from_bin(const char *plist_bin, uint32_t length, plist_t * plist);
 
     /**
      * Import the #plist_t structure from JSON format.
@@ -796,7 +810,7 @@ extern "C"
      * @param plist a pointer to the imported plist.
      * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure
      */
-    plist_err_t plist_from_json(const char *json, uint32_t length, plist_t * plist);
+    PLIST_API plist_err_t plist_from_json(const char *json, uint32_t length, plist_t * plist);
 
     /**
      * Import the #plist_t structure from OpenStep plist format.
@@ -806,7 +820,7 @@ extern "C"
      * @param plist a pointer to the imported plist.
      * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure
      */
-    plist_err_t plist_from_openstep(const char *openstep, uint32_t length, plist_t * plist);
+    PLIST_API plist_err_t plist_from_openstep(const char *openstep, uint32_t length, plist_t * plist);
 
     /**
      * Import the #plist_t structure from memory data.
@@ -826,7 +840,7 @@ extern "C"
      * @param format If non-NULL, the #plist_format_t value pointed to will be set to the parsed format.
      * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure
      */
-    plist_err_t plist_from_memory(const char *plist_data, uint32_t length, plist_t *plist, plist_format_t *format);
+    PLIST_API plist_err_t plist_from_memory(const char *plist_data, uint32_t length, plist_t *plist, plist_format_t *format);
 
     /**
      * Import the #plist_t structure directly from file.
@@ -841,7 +855,7 @@ extern "C"
      * @param format If non-NULL, the #plist_format_t value pointed to will be set to the parsed format.
      * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure
      */
-    plist_err_t plist_read_from_file(const char *filename, plist_t *plist, plist_format_t *format);
+    PLIST_API plist_err_t plist_read_from_file(const char *filename, plist_t *plist, plist_format_t *format);
 
     /**
      * Write the #plist_t structure to a NULL-terminated string using the given format and options.
@@ -856,7 +870,7 @@ extern "C"
      * @note Use plist_mem_free() to free the allocated memory.
      * @note #PLIST_FORMAT_BINARY is not supported by this function.
      */
-    plist_err_t plist_write_to_string(plist_t plist, char **output, uint32_t* length, plist_format_t format, plist_write_options_t options);
+    PLIST_API plist_err_t plist_write_to_string(plist_t plist, char **output, uint32_t* length, plist_format_t format, plist_write_options_t options);
 
     /**
      * Write the #plist_t structure to a FILE* stream using the given format and options.
@@ -871,7 +885,7 @@ extern "C"
      *     (basically all output-only formats) are directly and efficiently written to the stream;
      *     the other formats are written to a memory buffer first.
      */
-    plist_err_t plist_write_to_stream(plist_t plist, FILE* stream, plist_format_t format, plist_write_options_t options);
+    PLIST_API plist_err_t plist_write_to_stream(plist_t plist, FILE* stream, plist_format_t format, plist_write_options_t options);
 
     /**
      * Write the #plist_t structure to a file at given path using the given format and options.
@@ -883,7 +897,21 @@ extern "C"
      * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure.
      * @note Use plist_mem_free() to free the allocated memory.
      */
-    plist_err_t plist_write_to_file(plist_t plist, const char *filename, plist_format_t format, plist_write_options_t options);
+    PLIST_API plist_err_t plist_write_to_file(plist_t plist, const char *filename, plist_format_t format, plist_write_options_t options);
+
+    /**
+     * Print the given plist in human-readable format to standard output.
+     * This is equivalent to
+     * <code>plist_write_to_stream(plist, stdout, PLIST_FORMAT_PRINT, PLIST_OPT_PARTIAL_DATA);</code>
+     *
+     * @param plist The input plist structure
+     * @param filename The file name of the file to write to. Existing files will be overwritten.
+     * @param format A #plist_format_t value that specifies the output format to use.
+     * @param options One or more bitwise ORed values of #plist_write_options_t.
+     * @return PLIST_ERR_SUCCESS on success or a #plist_err_t on failure.
+     * @note Use plist_mem_free() to free the allocated memory.
+     */
+    PLIST_API plist_err_t plist_write_to_file(plist_t plist, const char *filename, plist_format_t format, plist_write_options_t options);
 
     /**
      * Print the given plist in human-readable format to standard output.
@@ -892,7 +920,7 @@ extern "C"
      * @param plist The #plist_t structure to print
      * @note For #PLIST_DATA nodes, only a maximum of 24 bytes (first 16 and last 8) are written.
      */
-    void plist_print(plist_t plist);
+    PLIST_API void plist_print(plist_t plist);
 
     /**
      * Test if in-memory plist data is in binary format.
@@ -906,7 +934,7 @@ extern "C"
      * @param length length of the buffer to read.
      * @return 1 if the buffer is a binary plist, 0 otherwise.
      */
-    int plist_is_binary(const char *plist_data, uint32_t length);
+    PLIST_API int plist_is_binary(const char *plist_data, uint32_t length);
 
     /********************************************
      *                                          *
@@ -923,7 +951,7 @@ extern "C"
      * @param length length of the path to access
      * @return the value to access.
      */
-    plist_t plist_access_path(plist_t plist, uint32_t length, ...);
+    PLIST_API plist_t plist_access_path(plist_t plist, uint32_t length, ...);
 
     /**
      * Variadic version of #plist_access_path.
@@ -933,7 +961,7 @@ extern "C"
      * @param v list of array's index and dic'st key
      * @return the value to access.
      */
-    plist_t plist_access_pathv(plist_t plist, uint32_t length, va_list v);
+    PLIST_API plist_t plist_access_pathv(plist_t plist, uint32_t length, va_list v);
 
     /**
      * Compare two node values
@@ -942,7 +970,7 @@ extern "C"
      * @param node_r rigth node to compare
      * @return TRUE is type and value match, FALSE otherwise.
      */
-    char plist_compare_node_value(plist_t node_l, plist_t node_r);
+    PLIST_API char plist_compare_node_value(plist_t node_l, plist_t node_r);
 
     #define _PLIST_IS_TYPE(__plist, __plist_type) (__plist && (plist_get_node_type(__plist) == PLIST_##__plist_type))
 
@@ -966,7 +994,7 @@ extern "C"
      * @param boolnode node of type PLIST_BOOL
      * @return 1 if the boolean node has a value of TRUE or 0 if FALSE.
      */
-    int plist_bool_val_is_true(plist_t boolnode);
+    PLIST_API int plist_bool_val_is_true(plist_t boolnode);
 
     /**
      * Helper function to test if a given #PLIST_INT node's value is negative
@@ -974,7 +1002,7 @@ extern "C"
      * @param intnode node of type PLIST_INT
      * @return 1 if the node's value is negative, or 0 if positive.
      */
-    int plist_int_val_is_negative(plist_t intnode);
+    PLIST_API int plist_int_val_is_negative(plist_t intnode);
 
     /**
      * Helper function to compare the value of a PLIST_INT node against
@@ -986,7 +1014,7 @@ extern "C"
      *         1 if the node's value is greater than cmpval,
      *         or -1 if the node's value is less than cmpval.
      */
-    int plist_int_val_compare(plist_t uintnode, int64_t cmpval);
+    PLIST_API int plist_int_val_compare(plist_t uintnode, int64_t cmpval);
 
     /**
      * Helper function to compare the value of a PLIST_INT node against
@@ -998,7 +1026,7 @@ extern "C"
      *         1 if the node's value is greater than cmpval,
      *         or -1 if the node's value is less than cmpval.
      */
-    int plist_uint_val_compare(plist_t uintnode, uint64_t cmpval);
+    PLIST_API int plist_uint_val_compare(plist_t uintnode, uint64_t cmpval);
 
     /**
      * Helper function to compare the value of a PLIST_UID node against
@@ -1010,7 +1038,7 @@ extern "C"
      *         1 if the node's value is greater than cmpval,
      *         or -1 if the node's value is less than cmpval.
      */
-    int plist_uid_val_compare(plist_t uidnode, uint64_t cmpval);
+    PLIST_API int plist_uid_val_compare(plist_t uidnode, uint64_t cmpval);
 
     /**
      * Helper function to compare the value of a PLIST_REAL node against
@@ -1027,7 +1055,7 @@ extern "C"
      *         1 if the node's value is greater than cmpval,
      *         or -1 if the node's value is less than cmpval.
      */
-    int plist_real_val_compare(plist_t realnode, double cmpval);
+    PLIST_API int plist_real_val_compare(plist_t realnode, double cmpval);
 
     /**
      * Helper function to compare the value of a PLIST_DATE node against
@@ -1040,7 +1068,7 @@ extern "C"
      *         1 if the node's date is greater than the supplied values,
      *         or -1 if the node's date is less than the supplied values.
      */
-    int plist_date_val_compare(plist_t datenode, int32_t cmpsec, int32_t cmpusec);
+    PLIST_API int plist_date_val_compare(plist_t datenode, int32_t cmpsec, int32_t cmpusec);
 
     /**
      * Helper function to compare the value of a PLIST_STRING node against
@@ -1053,7 +1081,7 @@ extern "C"
      *     > 0 if the node's value is lexicographically greater than cmpval,
      *     or < 0 if the node's value is lexicographically less than cmpval.
      */
-    int plist_string_val_compare(plist_t strnode, const char* cmpval);
+    PLIST_API int plist_string_val_compare(plist_t strnode, const char* cmpval);
 
     /**
      * Helper function to compare the value of a PLIST_STRING node against
@@ -1067,7 +1095,7 @@ extern "C"
      *     > 0 if the node's value is lexicographically greater than cmpval,
      *     or < 0 if the node's value is lexicographically less than cmpval.
      */
-    int plist_string_val_compare_with_size(plist_t strnode, const char* cmpval, size_t n);
+    PLIST_API int plist_string_val_compare_with_size(plist_t strnode, const char* cmpval, size_t n);
 
     /**
      * Helper function to match a given substring in the value of a
@@ -1078,7 +1106,7 @@ extern "C"
      * @return 1 if the node's value contains the given substring,
      *     or 0 if not.
      */
-    int plist_string_val_contains(plist_t strnode, const char* substr);
+    PLIST_API int plist_string_val_contains(plist_t strnode, const char* substr);
 
     /**
      * Helper function to compare the value of a PLIST_KEY node against
@@ -1091,7 +1119,7 @@ extern "C"
      *     > 0 if the node's value is lexicographically greater than cmpval,
      *     or < 0 if the node's value is lexicographically less than cmpval.
      */
-    int plist_key_val_compare(plist_t keynode, const char* cmpval);
+    PLIST_API int plist_key_val_compare(plist_t keynode, const char* cmpval);
 
     /**
      * Helper function to compare the value of a PLIST_KEY node against
@@ -1105,7 +1133,7 @@ extern "C"
      *     > 0 if the node's value is lexicographically greater than cmpval,
      *     or < 0 if the node's value is lexicographically less than cmpval.
      */
-    int plist_key_val_compare_with_size(plist_t keynode, const char* cmpval, size_t n);
+    PLIST_API int plist_key_val_compare_with_size(plist_t keynode, const char* cmpval, size_t n);
 
     /**
      * Helper function to match a given substring in the value of a
@@ -1116,7 +1144,7 @@ extern "C"
      * @return 1 if the node's value contains the given substring,
      *     or 0 if not.
      */
-    int plist_key_val_contains(plist_t keynode, const char* substr);
+    PLIST_API int plist_key_val_contains(plist_t keynode, const char* substr);
 
     /**
      * Helper function to compare the data of a PLIST_DATA node against
@@ -1132,23 +1160,9 @@ extern "C"
      *     > 0 if the node's value is lexicographically greater than cmpval,
      *     or < 0 if the node's value is lexicographically less than cmpval.
      */
-    int plist_data_val_compare(plist_t datanode, const uint8_t* cmpval, size_t n);
+    PLIST_API int plist_data_val_compare(plist_t datanode, const uint8_t* cmpval, size_t n);
 
-    /**
-     * Helper function to compare the data of a PLIST_DATA node against
-     * a given blob and size, while no more than n bytes are compared.
-     * This function basically behaves like memcmp after making sure the
-     * size of the node's data value is at least n, making this a
-     * "starts with" comparison.
-     *
-     * @param datanode node of type PLIST_DATA
-     * @param cmpval data blob to compare against
-     * @param n size of data blob passed in cmpval
-     * @return 0 if the node's value and cmpval are equal,
-     *     > 0 if the node's value is lexicographically greater than cmpval,
-     *     or < 0 if the node's value is lexicographically less than cmpval.
-     */
-    int plist_data_val_compare_with_size(plist_t datanode, const uint8_t* cmpval, size_t n);
+    PLIST_API int plist_data_val_compare_with_size(plist_t datanode, const uint8_t* cmpval, size_t n);
 
     /**
      * Helper function to match a given data blob within the value of a
@@ -1160,7 +1174,7 @@ extern "C"
      * @return 1 if the node's value contains the given data blob
      *     or 0 if not.
      */
-    int plist_data_val_contains(plist_t datanode, const uint8_t* cmpval, size_t n);
+    PLIST_API int plist_data_val_contains(plist_t datanode, const uint8_t* cmpval, size_t n);
 
     /**
      * Sort all PLIST_DICT key/value pairs in a property list lexicographically
@@ -1168,7 +1182,7 @@ extern "C"
      *
      * @param plist The property list to perform the sorting operation on.
      */
-    void plist_sort(plist_t plist);
+    PLIST_API void plist_sort(plist_t plist);
 
     /**
      * Free memory allocated by relevant libplist API calls:
@@ -1183,7 +1197,7 @@ extern "C"
      * @note Do not use this function to free plist_t nodes, use plist_free()
      *     instead.
      */
-    void plist_mem_free(void* ptr);
+    PLIST_API void plist_mem_free(void* ptr);
 
     /**
      * Set debug level for the format parsers.
@@ -1191,7 +1205,7 @@ extern "C"
      *
      * @param debug Debug level. Currently, only 0 (off) and 1 (enabled) are supported.
      */
-    void plist_set_debug(int debug);
+    PLIST_API void plist_set_debug(int debug);
 
     /*@}*/
 

--- a/src/bplist.c
+++ b/src/bplist.c
@@ -781,7 +781,7 @@ static plist_t parse_bin_node_at_index(struct bplist_data *bplist, uint32_t node
     return plist;
 }
 
-PLIST_API plist_err_t plist_from_bin(const char *plist_bin, uint32_t length, plist_t * plist)
+plist_err_t plist_from_bin(const char *plist_bin, uint32_t length, plist_t * plist)
 {
     bplist_trailer_t *trailer = NULL;
     uint8_t offset_size = 0;
@@ -1191,7 +1191,7 @@ static int is_ascii_string(char* s, int len)
   return ret;
 }
 
-PLIST_API plist_err_t plist_to_bin(plist_t plist, char **plist_bin, uint32_t * length)
+plist_err_t plist_to_bin(plist_t plist, char **plist_bin, uint32_t * length)
 {
     ptrarray_t* objects = NULL;
     hashtable_t* ref_table = NULL;

--- a/src/jplist.c
+++ b/src/jplist.c
@@ -395,7 +395,7 @@ static int node_estimate_size(node_t node, uint64_t *size, uint32_t depth, int p
     return PLIST_ERR_SUCCESS;
 }
 
-PLIST_API int plist_to_json(plist_t plist, char **json, uint32_t* length, int prettify)
+int plist_to_json(plist_t plist, char **json, uint32_t* length, int prettify)
 {
     uint64_t size = 0;
     int res;
@@ -779,7 +779,7 @@ static plist_t parse_object(const char* js, jsmntok_info_t* ti, int* index)
     return obj;
 }
 
-PLIST_API int plist_from_json(const char *json, uint32_t length, plist_t * plist)
+int plist_from_json(const char *json, uint32_t length, plist_t * plist)
 {
     if (!plist) {
         return PLIST_ERR_INVALID_ARG;

--- a/src/oplist.c
+++ b/src/oplist.c
@@ -439,7 +439,7 @@ static int node_estimate_size(node_t node, uint64_t *size, uint32_t depth, int p
     return PLIST_ERR_SUCCESS;
 }
 
-PLIST_API int plist_to_openstep(plist_t plist, char **openstep, uint32_t* length, int prettify)
+int plist_to_openstep(plist_t plist, char **openstep, uint32_t* length, int prettify)
 {
     uint64_t size = 0;
     int res;
@@ -892,7 +892,7 @@ err_out:
     return PLIST_ERR_SUCCESS;
 }
 
-PLIST_API int plist_from_openstep(const char *plist_ostep, uint32_t length, plist_t * plist)
+int plist_from_openstep(const char *plist_ostep, uint32_t length, plist_t * plist)
 {
     if (!plist) {
         return PLIST_ERR_INVALID_ARG;

--- a/src/plist.c
+++ b/src/plist.c
@@ -183,7 +183,7 @@ void* memmem(const void* haystack, size_t haystack_len, const void* needle, size
 }
 #endif
 
-PLIST_API int plist_is_binary(const char *plist_data, uint32_t length)
+int plist_is_binary(const char *plist_data, uint32_t length)
 {
     if (length < 8) {
         return 0;
@@ -197,7 +197,7 @@ PLIST_API int plist_is_binary(const char *plist_data, uint32_t length)
 #define FIND_NEXT(blob, pos, len, chr) \
     while (pos < len && (blob[pos] != chr)) pos++;
 
-PLIST_API plist_err_t plist_from_memory(const char *plist_data, uint32_t length, plist_t *plist, plist_format_t *format)
+plist_err_t plist_from_memory(const char *plist_data, uint32_t length, plist_t *plist, plist_format_t *format)
 {
     int res = -1;
     if (!plist) {
@@ -266,7 +266,7 @@ PLIST_API plist_err_t plist_from_memory(const char *plist_data, uint32_t length,
     return res;
 }
 
-PLIST_API plist_err_t plist_read_from_file(const char *filename, plist_t *plist, plist_format_t *format)
+plist_err_t plist_read_from_file(const char *filename, plist_t *plist, plist_format_t *format)
 {
     if (!filename || !plist) {
         return PLIST_ERR_INVALID_ARG;
@@ -396,14 +396,14 @@ static int plist_free_node(node_t node)
     return node_index;
 }
 
-PLIST_API plist_t plist_new_dict(void)
+plist_t plist_new_dict(void)
 {
     plist_data_t data = plist_new_plist_data();
     data->type = PLIST_DICT;
     return plist_new_node(data);
 }
 
-PLIST_API plist_t plist_new_array(void)
+plist_t plist_new_array(void)
 {
     plist_data_t data = plist_new_plist_data();
     data->type = PLIST_ARRAY;
@@ -420,7 +420,7 @@ static plist_t plist_new_key(const char *val)
     return plist_new_node(data);
 }
 
-PLIST_API plist_t plist_new_string(const char *val)
+plist_t plist_new_string(const char *val)
 {
     plist_data_t data = plist_new_plist_data();
     data->type = PLIST_STRING;
@@ -429,7 +429,7 @@ PLIST_API plist_t plist_new_string(const char *val)
     return plist_new_node(data);
 }
 
-PLIST_API plist_t plist_new_bool(uint8_t val)
+plist_t plist_new_bool(uint8_t val)
 {
     plist_data_t data = plist_new_plist_data();
     data->type = PLIST_BOOLEAN;
@@ -438,7 +438,7 @@ PLIST_API plist_t plist_new_bool(uint8_t val)
     return plist_new_node(data);
 }
 
-PLIST_API plist_t plist_new_uint(uint64_t val)
+plist_t plist_new_uint(uint64_t val)
 {
     plist_data_t data = plist_new_plist_data();
     data->type = PLIST_INT;
@@ -447,7 +447,7 @@ PLIST_API plist_t plist_new_uint(uint64_t val)
     return plist_new_node(data);
 }
 
-PLIST_API plist_t plist_new_int(int64_t val)
+plist_t plist_new_int(int64_t val)
 {
     plist_data_t data = plist_new_plist_data();
     data->type = PLIST_INT;
@@ -456,7 +456,7 @@ PLIST_API plist_t plist_new_int(int64_t val)
     return plist_new_node(data);
 }
 
-PLIST_API plist_t plist_new_uid(uint64_t val)
+plist_t plist_new_uid(uint64_t val)
 {
     plist_data_t data = plist_new_plist_data();
     data->type = PLIST_UID;
@@ -465,7 +465,7 @@ PLIST_API plist_t plist_new_uid(uint64_t val)
     return plist_new_node(data);
 }
 
-PLIST_API plist_t plist_new_real(double val)
+plist_t plist_new_real(double val)
 {
     plist_data_t data = plist_new_plist_data();
     data->type = PLIST_REAL;
@@ -474,7 +474,7 @@ PLIST_API plist_t plist_new_real(double val)
     return plist_new_node(data);
 }
 
-PLIST_API plist_t plist_new_data(const char *val, uint64_t length)
+plist_t plist_new_data(const char *val, uint64_t length)
 {
     plist_data_t data = plist_new_plist_data();
     data->type = PLIST_DATA;
@@ -484,7 +484,7 @@ PLIST_API plist_t plist_new_data(const char *val, uint64_t length)
     return plist_new_node(data);
 }
 
-PLIST_API plist_t plist_new_date(int32_t sec, int32_t usec)
+plist_t plist_new_date(int32_t sec, int32_t usec)
 {
     plist_data_t data = plist_new_plist_data();
     data->type = PLIST_DATE;
@@ -493,7 +493,7 @@ PLIST_API plist_t plist_new_date(int32_t sec, int32_t usec)
     return plist_new_node(data);
 }
 
-PLIST_API plist_t plist_new_null(void)
+plist_t plist_new_null(void)
 {
     plist_data_t data = plist_new_plist_data();
     data->type = PLIST_NULL;
@@ -502,7 +502,7 @@ PLIST_API plist_t plist_new_null(void)
     return plist_new_node(data);
 }
 
-PLIST_API void plist_free(plist_t plist)
+void plist_free(plist_t plist)
 {
     if (plist)
     {
@@ -510,7 +510,7 @@ PLIST_API void plist_free(plist_t plist)
     }
 }
 
-PLIST_API void plist_mem_free(void* ptr)
+void plist_mem_free(void* ptr)
 {
     if (ptr)
     {
@@ -586,12 +586,12 @@ static plist_t plist_copy_node(node_t node)
     return newnode;
 }
 
-PLIST_API plist_t plist_copy(plist_t node)
+plist_t plist_copy(plist_t node)
 {
     return node ? plist_copy_node(node) : NULL;
 }
 
-PLIST_API uint32_t plist_array_get_size(plist_t node)
+uint32_t plist_array_get_size(plist_t node)
 {
     uint32_t ret = 0;
     if (node && PLIST_ARRAY == plist_get_node_type(node))
@@ -601,7 +601,7 @@ PLIST_API uint32_t plist_array_get_size(plist_t node)
     return ret;
 }
 
-PLIST_API plist_t plist_array_get_item(plist_t node, uint32_t n)
+plist_t plist_array_get_item(plist_t node, uint32_t n)
 {
     plist_t ret = NULL;
     if (node && PLIST_ARRAY == plist_get_node_type(node) && n < INT_MAX)
@@ -616,7 +616,7 @@ PLIST_API plist_t plist_array_get_item(plist_t node, uint32_t n)
     return ret;
 }
 
-PLIST_API uint32_t plist_array_get_item_index(plist_t node)
+uint32_t plist_array_get_item_index(plist_t node)
 {
     plist_t father = plist_get_parent(node);
     if (PLIST_ARRAY == plist_get_node_type(father))
@@ -648,7 +648,7 @@ static void _plist_array_post_insert(plist_t node, plist_t item, long n)
     }
 }
 
-PLIST_API void plist_array_set_item(plist_t node, plist_t item, uint32_t n)
+void plist_array_set_item(plist_t node, plist_t item, uint32_t n)
 {
     if (node && PLIST_ARRAY == plist_get_node_type(node) && n < INT_MAX)
     {
@@ -669,7 +669,7 @@ PLIST_API void plist_array_set_item(plist_t node, plist_t item, uint32_t n)
     }
 }
 
-PLIST_API void plist_array_append_item(plist_t node, plist_t item)
+void plist_array_append_item(plist_t node, plist_t item)
 {
     if (node && PLIST_ARRAY == plist_get_node_type(node))
     {
@@ -678,7 +678,7 @@ PLIST_API void plist_array_append_item(plist_t node, plist_t item)
     }
 }
 
-PLIST_API void plist_array_insert_item(plist_t node, plist_t item, uint32_t n)
+void plist_array_insert_item(plist_t node, plist_t item, uint32_t n)
 {
     if (node && PLIST_ARRAY == plist_get_node_type(node) && n < INT_MAX)
     {
@@ -687,7 +687,7 @@ PLIST_API void plist_array_insert_item(plist_t node, plist_t item, uint32_t n)
     }
 }
 
-PLIST_API void plist_array_remove_item(plist_t node, uint32_t n)
+void plist_array_remove_item(plist_t node, uint32_t n)
 {
     if (node && PLIST_ARRAY == plist_get_node_type(node) && n < INT_MAX)
     {
@@ -703,7 +703,7 @@ PLIST_API void plist_array_remove_item(plist_t node, uint32_t n)
     }
 }
 
-PLIST_API void plist_array_item_remove(plist_t node)
+void plist_array_item_remove(plist_t node)
 {
     plist_t father = plist_get_parent(node);
     if (PLIST_ARRAY == plist_get_node_type(father))
@@ -718,7 +718,7 @@ PLIST_API void plist_array_item_remove(plist_t node)
     }
 }
 
-PLIST_API void plist_array_new_iter(plist_t node, plist_array_iter *iter)
+void plist_array_new_iter(plist_t node, plist_array_iter *iter)
 {
     if (iter)
     {
@@ -727,7 +727,7 @@ PLIST_API void plist_array_new_iter(plist_t node, plist_array_iter *iter)
     }
 }
 
-PLIST_API void plist_array_next_item(plist_t node, plist_array_iter iter, plist_t *item)
+void plist_array_next_item(plist_t node, plist_array_iter iter, plist_t *item)
 {
     node_t* iter_node = (node_t*)iter;
 
@@ -746,7 +746,7 @@ PLIST_API void plist_array_next_item(plist_t node, plist_array_iter iter, plist_
     }
 }
 
-PLIST_API uint32_t plist_dict_get_size(plist_t node)
+uint32_t plist_dict_get_size(plist_t node)
 {
     uint32_t ret = 0;
     if (node && PLIST_DICT == plist_get_node_type(node))
@@ -756,7 +756,7 @@ PLIST_API uint32_t plist_dict_get_size(plist_t node)
     return ret;
 }
 
-PLIST_API void plist_dict_new_iter(plist_t node, plist_dict_iter *iter)
+void plist_dict_new_iter(plist_t node, plist_dict_iter *iter)
 {
     if (iter)
     {
@@ -765,7 +765,7 @@ PLIST_API void plist_dict_new_iter(plist_t node, plist_dict_iter *iter)
     }
 }
 
-PLIST_API void plist_dict_next_item(plist_t node, plist_dict_iter iter, char **key, plist_t *val)
+void plist_dict_next_item(plist_t node, plist_dict_iter iter, char **key, plist_t *val)
 {
     node_t* iter_node = (node_t*)iter;
 
@@ -793,7 +793,7 @@ PLIST_API void plist_dict_next_item(plist_t node, plist_dict_iter iter, char **k
     }
 }
 
-PLIST_API void plist_dict_get_item_key(plist_t node, char **key)
+void plist_dict_get_item_key(plist_t node, char **key)
 {
     plist_t father = plist_get_parent(node);
     if (PLIST_DICT == plist_get_node_type(father))
@@ -802,7 +802,7 @@ PLIST_API void plist_dict_get_item_key(plist_t node, char **key)
     }
 }
 
-PLIST_API plist_t plist_dict_item_get_key(plist_t node)
+plist_t plist_dict_item_get_key(plist_t node)
 {
     plist_t ret = NULL;
     plist_t father = plist_get_parent(node);
@@ -813,7 +813,7 @@ PLIST_API plist_t plist_dict_item_get_key(plist_t node)
     return ret;
 }
 
-PLIST_API plist_t plist_dict_get_item(plist_t node, const char* key)
+plist_t plist_dict_get_item(plist_t node, const char* key)
 {
     plist_t ret = NULL;
 
@@ -846,7 +846,7 @@ PLIST_API plist_t plist_dict_get_item(plist_t node, const char* key)
     return ret;
 }
 
-PLIST_API void plist_dict_set_item(plist_t node, const char* key, plist_t item)
+void plist_dict_set_item(plist_t node, const char* key, plist_t item)
 {
     if (node && PLIST_DICT == plist_get_node_type(node)) {
         node_t old_item = plist_dict_get_item(node, key);
@@ -887,7 +887,7 @@ PLIST_API void plist_dict_set_item(plist_t node, const char* key, plist_t item)
     }
 }
 
-PLIST_API void plist_dict_remove_item(plist_t node, const char* key)
+void plist_dict_remove_item(plist_t node, const char* key)
 {
     if (node && PLIST_DICT == plist_get_node_type(node))
     {
@@ -905,7 +905,7 @@ PLIST_API void plist_dict_remove_item(plist_t node, const char* key)
     }
 }
 
-PLIST_API void plist_dict_merge(plist_t *target, plist_t source)
+void plist_dict_merge(plist_t *target, plist_t source)
 {
 	if (!target || !*target || (plist_get_node_type(*target) != PLIST_DICT) || !source || (plist_get_node_type(source) != PLIST_DICT))
 		return;
@@ -929,7 +929,7 @@ PLIST_API void plist_dict_merge(plist_t *target, plist_t source)
 	free(it);
 }
 
-PLIST_API plist_t plist_access_pathv(plist_t plist, uint32_t length, va_list v)
+plist_t plist_access_pathv(plist_t plist, uint32_t length, va_list v)
 {
     plist_t current = plist;
     plist_type type = PLIST_NONE;
@@ -953,7 +953,7 @@ PLIST_API plist_t plist_access_pathv(plist_t plist, uint32_t length, va_list v)
     return current;
 }
 
-PLIST_API plist_t plist_access_path(plist_t plist, uint32_t length, ...)
+plist_t plist_access_path(plist_t plist, uint32_t length, ...)
 {
     plist_t ret = NULL;
     va_list v;
@@ -1004,12 +1004,12 @@ static void plist_get_type_and_value(plist_t node, plist_type * type, void *valu
     }
 }
 
-PLIST_API plist_t plist_get_parent(plist_t node)
+plist_t plist_get_parent(plist_t node)
 {
     return node ? (plist_t) ((node_t) node)->parent : NULL;
 }
 
-PLIST_API plist_type plist_get_node_type(plist_t node)
+plist_type plist_get_node_type(plist_t node)
 {
     if (node)
     {
@@ -1020,7 +1020,7 @@ PLIST_API plist_type plist_get_node_type(plist_t node)
     return PLIST_NONE;
 }
 
-PLIST_API void plist_get_key_val(plist_t node, char **val)
+void plist_get_key_val(plist_t node, char **val)
 {
     if (!node || !val)
         return;
@@ -1034,7 +1034,7 @@ PLIST_API void plist_get_key_val(plist_t node, char **val)
     assert(length == strlen(*val));
 }
 
-PLIST_API void plist_get_string_val(plist_t node, char **val)
+void plist_get_string_val(plist_t node, char **val)
 {
     if (!node || !val)
         return;
@@ -1048,7 +1048,7 @@ PLIST_API void plist_get_string_val(plist_t node, char **val)
     assert(length == strlen(*val));
 }
 
-PLIST_API const char* plist_get_string_ptr(plist_t node, uint64_t* length)
+const char* plist_get_string_ptr(plist_t node, uint64_t* length)
 {
     if (!node)
         return NULL;
@@ -1061,7 +1061,7 @@ PLIST_API const char* plist_get_string_ptr(plist_t node, uint64_t* length)
     return (const char*)data->strval;
 }
 
-PLIST_API void plist_get_bool_val(plist_t node, uint8_t * val)
+void plist_get_bool_val(plist_t node, uint8_t * val)
 {
     if (!node || !val)
         return;
@@ -1073,7 +1073,7 @@ PLIST_API void plist_get_bool_val(plist_t node, uint8_t * val)
     assert(length == sizeof(uint8_t));
 }
 
-PLIST_API void plist_get_uint_val(plist_t node, uint64_t * val)
+void plist_get_uint_val(plist_t node, uint64_t * val)
 {
     if (!node || !val)
         return;
@@ -1085,12 +1085,12 @@ PLIST_API void plist_get_uint_val(plist_t node, uint64_t * val)
     assert(length == sizeof(uint64_t) || length == 16);
 }
 
-PLIST_API void plist_get_int_val(plist_t node, int64_t * val)
+void plist_get_int_val(plist_t node, int64_t * val)
 {
     plist_get_uint_val(node, (uint64_t*)val);
 }
 
-PLIST_API void plist_get_uid_val(plist_t node, uint64_t * val)
+void plist_get_uid_val(plist_t node, uint64_t * val)
 {
     if (!node || !val)
         return;
@@ -1102,7 +1102,7 @@ PLIST_API void plist_get_uid_val(plist_t node, uint64_t * val)
     assert(length == sizeof(uint64_t));
 }
 
-PLIST_API void plist_get_real_val(plist_t node, double *val)
+void plist_get_real_val(plist_t node, double *val)
 {
     if (!node || !val)
         return;
@@ -1114,7 +1114,7 @@ PLIST_API void plist_get_real_val(plist_t node, double *val)
     assert(length == sizeof(double));
 }
 
-PLIST_API void plist_get_data_val(plist_t node, char **val, uint64_t * length)
+void plist_get_data_val(plist_t node, char **val, uint64_t * length)
 {
     if (!node || !val || !length)
         return;
@@ -1124,7 +1124,7 @@ PLIST_API void plist_get_data_val(plist_t node, char **val, uint64_t * length)
     plist_get_type_and_value(node, &type, (void *) val, length);
 }
 
-PLIST_API const char* plist_get_data_ptr(plist_t node, uint64_t* length)
+const char* plist_get_data_ptr(plist_t node, uint64_t* length)
 {
     if (!node || !length)
         return NULL;
@@ -1136,7 +1136,7 @@ PLIST_API const char* plist_get_data_ptr(plist_t node, uint64_t* length)
     return (const char*)data->buff;
 }
 
-PLIST_API void plist_get_date_val(plist_t node, int32_t * sec, int32_t * usec)
+void plist_get_date_val(plist_t node, int32_t * sec, int32_t * usec)
 {
     if (!node)
         return;
@@ -1205,7 +1205,7 @@ int plist_data_compare(const void *a, const void *b)
     return FALSE;
 }
 
-PLIST_API char plist_compare_node_value(plist_t node_l, plist_t node_r)
+char plist_compare_node_value(plist_t node_l, plist_t node_r)
 {
     return plist_data_compare(node_l, node_r);
 }
@@ -1264,7 +1264,7 @@ static void plist_set_element_val(plist_t node, plist_type type, const void *val
     }
 }
 
-PLIST_API void plist_set_key_val(plist_t node, const char *val)
+void plist_set_key_val(plist_t node, const char *val)
 {
     plist_t father = plist_get_parent(node);
     plist_t item = plist_dict_get_item(father, val);
@@ -1274,48 +1274,48 @@ PLIST_API void plist_set_key_val(plist_t node, const char *val)
     plist_set_element_val(node, PLIST_KEY, val, strlen(val));
 }
 
-PLIST_API void plist_set_string_val(plist_t node, const char *val)
+void plist_set_string_val(plist_t node, const char *val)
 {
     plist_set_element_val(node, PLIST_STRING, val, strlen(val));
 }
 
-PLIST_API void plist_set_bool_val(plist_t node, uint8_t val)
+void plist_set_bool_val(plist_t node, uint8_t val)
 {
     plist_set_element_val(node, PLIST_BOOLEAN, &val, sizeof(uint8_t));
 }
 
-PLIST_API void plist_set_uint_val(plist_t node, uint64_t val)
+void plist_set_uint_val(plist_t node, uint64_t val)
 {
     plist_set_element_val(node, PLIST_INT, &val, (val > INT64_MAX) ? sizeof(uint64_t)*2 : sizeof(uint64_t));
 }
 
-PLIST_API void plist_set_int_val(plist_t node, int64_t val)
+void plist_set_int_val(plist_t node, int64_t val)
 {
     plist_set_element_val(node, PLIST_INT, &val, sizeof(uint64_t));
 }
 
-PLIST_API void plist_set_uid_val(plist_t node, uint64_t val)
+void plist_set_uid_val(plist_t node, uint64_t val)
 {
     plist_set_element_val(node, PLIST_UID, &val, sizeof(uint64_t));
 }
 
-PLIST_API void plist_set_real_val(plist_t node, double val)
+void plist_set_real_val(plist_t node, double val)
 {
     plist_set_element_val(node, PLIST_REAL, &val, sizeof(double));
 }
 
-PLIST_API void plist_set_data_val(plist_t node, const char *val, uint64_t length)
+void plist_set_data_val(plist_t node, const char *val, uint64_t length)
 {
     plist_set_element_val(node, PLIST_DATA, val, length);
 }
 
-PLIST_API void plist_set_date_val(plist_t node, int32_t sec, int32_t usec)
+void plist_set_date_val(plist_t node, int32_t sec, int32_t usec)
 {
     double val = (double)sec + (double)usec / 1000000;
     plist_set_element_val(node, PLIST_DATE, &val, sizeof(struct timeval));
 }
 
-PLIST_API int plist_bool_val_is_true(plist_t boolnode)
+int plist_bool_val_is_true(plist_t boolnode)
 {
     if (!PLIST_IS_BOOLEAN(boolnode)) {
         return 0;
@@ -1325,7 +1325,7 @@ PLIST_API int plist_bool_val_is_true(plist_t boolnode)
     return (bv == 1);
 }
 
-PLIST_API int plist_int_val_is_negative(plist_t intnode)
+int plist_int_val_is_negative(plist_t intnode)
 {
     if (!PLIST_IS_INT(intnode)) {
         return 0;
@@ -1340,7 +1340,7 @@ PLIST_API int plist_int_val_is_negative(plist_t intnode)
     return 0;
 }
 
-PLIST_API int plist_int_val_compare(plist_t uintnode, int64_t cmpval)
+int plist_int_val_compare(plist_t uintnode, int64_t cmpval)
 {
     if (!PLIST_IS_INT(uintnode)) {
         return -1;
@@ -1358,7 +1358,7 @@ PLIST_API int plist_int_val_compare(plist_t uintnode, int64_t cmpval)
     return 1;
 }
 
-PLIST_API int plist_uint_val_compare(plist_t uintnode, uint64_t cmpval)
+int plist_uint_val_compare(plist_t uintnode, uint64_t cmpval)
 {
     if (!PLIST_IS_INT(uintnode)) {
         return -1;
@@ -1376,7 +1376,7 @@ PLIST_API int plist_uint_val_compare(plist_t uintnode, uint64_t cmpval)
     return 1;
 }
 
-PLIST_API int plist_uid_val_compare(plist_t uidnode, uint64_t cmpval)
+int plist_uid_val_compare(plist_t uidnode, uint64_t cmpval)
 {
     if (!PLIST_IS_UID(uidnode)) {
         return -1;
@@ -1394,7 +1394,7 @@ PLIST_API int plist_uid_val_compare(plist_t uidnode, uint64_t cmpval)
     return 1;
 }
 
-PLIST_API int plist_real_val_compare(plist_t realnode, double cmpval)
+int plist_real_val_compare(plist_t realnode, double cmpval)
 {
     if (!PLIST_IS_REAL(realnode)) {
         return -1;
@@ -1429,7 +1429,7 @@ PLIST_API int plist_real_val_compare(plist_t realnode, double cmpval)
     return 1;
 }
 
-PLIST_API int plist_date_val_compare(plist_t datenode, int32_t cmpsec, int32_t cmpusec)
+int plist_date_val_compare(plist_t datenode, int32_t cmpsec, int32_t cmpusec)
 {
     if (!PLIST_IS_DATE(datenode)) {
         return -1;
@@ -1450,7 +1450,7 @@ PLIST_API int plist_date_val_compare(plist_t datenode, int32_t cmpsec, int32_t c
     return 1;
 }
 
-PLIST_API int plist_string_val_compare(plist_t strnode, const char* cmpval)
+int plist_string_val_compare(plist_t strnode, const char* cmpval)
 {
     if (!PLIST_IS_STRING(strnode)) {
         return -1;
@@ -1459,7 +1459,7 @@ PLIST_API int plist_string_val_compare(plist_t strnode, const char* cmpval)
     return strcmp(data->strval, cmpval);
 }
 
-PLIST_API int plist_string_val_compare_with_size(plist_t strnode, const char* cmpval, size_t n)
+int plist_string_val_compare_with_size(plist_t strnode, const char* cmpval, size_t n)
 {
     if (!PLIST_IS_STRING(strnode)) {
         return -1;
@@ -1468,7 +1468,7 @@ PLIST_API int plist_string_val_compare_with_size(plist_t strnode, const char* cm
     return strncmp(data->strval, cmpval, n);
 }
 
-PLIST_API int plist_string_val_contains(plist_t strnode, const char* substr)
+int plist_string_val_contains(plist_t strnode, const char* substr)
 {
     if (!PLIST_IS_STRING(strnode)) {
         return 0;
@@ -1477,7 +1477,7 @@ PLIST_API int plist_string_val_contains(plist_t strnode, const char* substr)
     return (strstr(data->strval, substr) != NULL);
 }
 
-PLIST_API int plist_key_val_compare(plist_t keynode, const char* cmpval)
+int plist_key_val_compare(plist_t keynode, const char* cmpval)
 {
     if (!PLIST_IS_KEY(keynode)) {
         return -1;
@@ -1486,7 +1486,7 @@ PLIST_API int plist_key_val_compare(plist_t keynode, const char* cmpval)
     return strcmp(data->strval, cmpval);
 }
 
-PLIST_API int plist_key_val_compare_with_size(plist_t keynode, const char* cmpval, size_t n)
+int plist_key_val_compare_with_size(plist_t keynode, const char* cmpval, size_t n)
 {
     if (!PLIST_IS_KEY(keynode)) {
         return -1;
@@ -1495,7 +1495,7 @@ PLIST_API int plist_key_val_compare_with_size(plist_t keynode, const char* cmpva
     return strncmp(data->strval, cmpval, n);
 }
 
-PLIST_API int plist_key_val_contains(plist_t keynode, const char* substr)
+int plist_key_val_contains(plist_t keynode, const char* substr)
 {
     if (!PLIST_IS_KEY(keynode)) {
         return 0;
@@ -1504,7 +1504,7 @@ PLIST_API int plist_key_val_contains(plist_t keynode, const char* substr)
     return (strstr(data->strval, substr) != NULL);
 }
 
-PLIST_API int plist_data_val_compare(plist_t datanode, const uint8_t* cmpval, size_t n)
+int plist_data_val_compare(plist_t datanode, const uint8_t* cmpval, size_t n)
 {
     if (!PLIST_IS_DATA(datanode)) {
         return -1;
@@ -1521,7 +1521,7 @@ PLIST_API int plist_data_val_compare(plist_t datanode, const uint8_t* cmpval, si
     return memcmp(data->buff, cmpval, n);
 }
 
-PLIST_API int plist_data_val_compare_with_size(plist_t datanode, const uint8_t* cmpval, size_t n)
+int plist_data_val_compare_with_size(plist_t datanode, const uint8_t* cmpval, size_t n)
 {
     if (!PLIST_IS_DATA(datanode)) {
         return -1;
@@ -1533,7 +1533,7 @@ PLIST_API int plist_data_val_compare_with_size(plist_t datanode, const uint8_t* 
     return memcmp(data->buff, cmpval, n);
 }
 
-PLIST_API int plist_data_val_contains(plist_t datanode, const uint8_t* cmpval, size_t n)
+int plist_data_val_contains(plist_t datanode, const uint8_t* cmpval, size_t n)
 {
     if (!PLIST_IS_DATA(datanode)) {
         return -1;
@@ -1547,7 +1547,7 @@ extern void plist_bin_set_debug(int debug);
 extern void plist_json_set_debug(int debug);
 extern void plist_ostep_set_debug(int debug);
 
-PLIST_API void plist_set_debug(int debug)
+void plist_set_debug(int debug)
 {
     plist_xml_set_debug(debug);
     plist_bin_set_debug(debug);
@@ -1555,7 +1555,7 @@ PLIST_API void plist_set_debug(int debug)
     plist_ostep_set_debug(debug);
 }
 
-PLIST_API void plist_sort(plist_t plist)
+void plist_sort(plist_t plist)
 {
     if (!plist) {
         return;
@@ -1619,7 +1619,7 @@ PLIST_API void plist_sort(plist_t plist)
     }
 }
 
-PLIST_API plist_err_t plist_write_to_string(plist_t plist, char **output, uint32_t* length, plist_format_t format, plist_write_options_t options)
+plist_err_t plist_write_to_string(plist_t plist, char **output, uint32_t* length, plist_format_t format, plist_write_options_t options)
 {
     plist_err_t err = PLIST_ERR_UNKNOWN;
     switch (format) {
@@ -1649,7 +1649,7 @@ PLIST_API plist_err_t plist_write_to_string(plist_t plist, char **output, uint32
     return err;
 }
 
-PLIST_API plist_err_t plist_write_to_stream(plist_t plist, FILE *stream, plist_format_t format, plist_write_options_t options)
+plist_err_t plist_write_to_stream(plist_t plist, FILE *stream, plist_format_t format, plist_write_options_t options)
 {
     if (!plist || !stream) {
         return PLIST_ERR_INVALID_ARG;
@@ -1692,7 +1692,7 @@ PLIST_API plist_err_t plist_write_to_stream(plist_t plist, FILE *stream, plist_f
     return err;
 }
 
-PLIST_API plist_err_t plist_write_to_file(plist_t plist, const char* filename, plist_format_t format, plist_write_options_t options)
+plist_err_t plist_write_to_file(plist_t plist, const char* filename, plist_format_t format, plist_write_options_t options)
 {
     if (!plist || !filename) {
         return PLIST_ERR_INVALID_ARG;
@@ -1706,7 +1706,7 @@ PLIST_API plist_err_t plist_write_to_file(plist_t plist, const char* filename, p
     return err;
 }
 
-PLIST_API void plist_print(plist_t plist)
+void plist_print(plist_t plist)
 {
      plist_write_to_stream(plist, stdout, PLIST_FORMAT_PRINT, PLIST_OPT_PARTIAL_DATA);
 }

--- a/src/plist.h
+++ b/src/plist.h
@@ -37,16 +37,6 @@
 #pragma warning(disable:4244)
 #endif
 
-#ifdef WIN32
-  #define PLIST_API __declspec( dllexport )
-#else
-  #ifdef HAVE_FVISIBILITY
-    #define PLIST_API __attribute__((visibility("default")))
-  #else
-    #define PLIST_API
-  #endif
-#endif
-
 struct plist_data_s
 {
     union

--- a/src/xplist.c
+++ b/src/xplist.c
@@ -529,7 +529,7 @@ static int node_estimate_size(node_t node, uint64_t *size, uint32_t depth)
     return PLIST_ERR_SUCCESS;
 }
 
-PLIST_API plist_err_t plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length)
+plist_err_t plist_to_xml(plist_t plist, char **plist_xml, uint32_t * length)
 {
     uint64_t size = 0;
     int res;
@@ -1471,7 +1471,7 @@ err_out:
     return PLIST_ERR_SUCCESS;
 }
 
-PLIST_API plist_err_t plist_from_xml(const char *plist_xml, uint32_t length, plist_t * plist)
+plist_err_t plist_from_xml(const char *plist_xml, uint32_t length, plist_t * plist)
 {
     if (!plist) {
         return PLIST_ERR_INVALID_ARG;


### PR DESCRIPTION
dllexport needs to be done in headers.

Also fix static compilation with MinGW. dllexport cannot be used there.

Original patch: https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-libplist/004-exports.patch