### PR TITLE
Allow building without Python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,9 +147,10 @@ AC_ARG_WITH([cython],
             [build_cython=false],
             [build_cython=true])
 if test "$build_cython" = "true"; then
-            AM_PATH_PYTHON(2.3)
-            AC_PROG_CYTHON(0.17.0)
-            CYTHON_PYTHON
+            AC_PROG_CYTHON([0.17.0])
+            if [test "x$CYTHON" != "xfalse"]; then
+              AM_PATH_PYTHON([2.3], [CYTHON_PYTHON])
+            fi
 else
             CYTHON=false
 fi


### PR DESCRIPTION
This allows building without the need for Python, it uses a similar technique to https://github.com/libimobiledevice/libimobiledevice/blob/eda2c5e/configure.ac#L123-L134.