### PR TITLE
Fix Cython dump method

### DIFF
--- a/cython/plist.pyx
+++ b/cython/plist.pyx
@@ -977,8 +977,10 @@ cpdef object dumps(value, fmt=FMT_XML, sort_keys=True, skipkeys=False):
         node = Dict(value)
     elif type(value) in (list, set, tuple):
         node = Array(value)
+    else:
+        node = value
 
     if fmt == FMT_XML:
-        return node.to_xml()
+        return node.to_xml().encode('utf-8')
 
     return node.to_bin()


### PR DESCRIPTION
This fixes the `dump` method by accepting plist objects and using the correct data type for XML files.

This code now works:
```
import plist

test = plist.loads(b'<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><array>\t<string>one</string></array></plist>')

with open('test-plist-xml.plist', 'wb') as fp:
  plist.dump(test, fp)

with open('test-plist-binary.plist', 'wb') as fp:
  plist.dump(test, fp, fmt=2)

with open('test-list-xml.plist', 'wb') as fp:
  plist.dump([1,2,3], fp)
```