### PR TITLE
Fix dictionary key deletion in Cython

### DIFF
--- a/cython/plist.pyx
+++ b/cython/plist.pyx
@@ -718,7 +718,7 @@ cdef class Dict(Node):
 
     def __delitem__(self, key):
         cpython.PyDict_DelItem(self._map, key)
-        plist_dict_remove_item(self._c_node, key)
+        plist_dict_remove_item(self._c_node, key.encode('utf-8'))
 
 cdef Dict Dict_factory(plist_t c_node, bint managed=True):
     cdef Dict instance = Dict.__new__(Dict)


### PR DESCRIPTION
This fixes the following error:
```
TypeError: expected bytes, str found
```

This code now works:
```
import plist

test = plist.loads(b'<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>k</key><string>v</string><key>k2</key><string>v2</string></dict></plist>')
del test['k']
```