### PR TITLE
configure: Use string for tm_zone assignment

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,7 @@ AC_CACHE_CHECK(for tm_zone in struct tm, ac_cv_struct_tm_zone,
       #include <time.h>
     ], [
       struct tm tm;
-      tm.tm_zone = 1;
+      tm.tm_zone = (char*)"UTC";
     ])],
     [ac_cv_struct_tm_zone=yes],
     [ac_cv_struct_tm_zone=no]


### PR DESCRIPTION
This matches what the actual sources do.  Clang 16 and GCC 14 no longer support converting ints to pointers implicitly, so the configure probe always fails with these compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
