### PR TITLE
Fix Integer constructor to copy plist node

### DIFF
--- a/src/Integer.cpp
+++ b/src/Integer.cpp
@@ -35,7 +35,8 @@ Integer::Integer(plist_t node, Node* parent) : Node(node, parent)
 
 Integer::Integer(const PList::Integer& i) : Node(PLIST_INT)
 {
-    plist_set_uint_val(_node, i.GetValue());
+    plist_free(_node);
+    _node = plist_copy(i.GetPlist());
 }
 
 Integer& Integer::operator=(const PList::Integer& i)


### PR DESCRIPTION
Updated the Integer(const PList::Integer&) constructor to free the existing plist node and copy the node from the input object, ensuring correct initialization.

Closes: #272 