### PR TITLE
plist: Check plist_data is not NULL before dereference

### DIFF
--- a/src/plist.c
+++ b/src/plist.c
@@ -210,7 +210,7 @@ void* memmem(const void* haystack, size_t haystack_len, const void* needle, size
 
 int plist_is_binary(const char *plist_data, uint32_t length)
 {
-    if (length < 8) {
+    if (!plist_data || length < 8) {
         return 0;
     }
 


### PR DESCRIPTION
Check if plist_data is NULL and returns before dereferencing/usage in memcmp.

Fixes #300 