### PR TITLE
Fix issue #303, add the Explicit type conversion to fix compile warning.

### DIFF
--- a/src/bplist.c
+++ b/src/bplist.c
@@ -1222,7 +1222,7 @@ static void write_unicode(bytearray_t * bplist, char *val, size_t size)
     size_t items_written = 0;
     uint16_t *unicodestr = NULL;
 
-    unicodestr = plist_utf8_to_utf16be(val, size, &items_read, &items_written);
+    unicodestr = plist_utf8_to_utf16be((const unsigned char *)val, size, &items_read, &items_written);
     write_raw_data(bplist, BPLIST_UNICODE, (uint8_t*)unicodestr, items_written);
     free(unicodestr);
 }


### PR DESCRIPTION
Fix the issue https://github.com/libimobiledevice/libplist/issues/303.

Before fix:
```
bplist.c: In function ‘write_unicode’:
bplist.c:1225:40: warning: pointer targets in passing argument 1 of ‘plist_utf8_to_utf16be’ differ in signedness [-Wpointer-sign]
 1225 |     unicodestr = plist_utf8_to_utf16be(val, size, &items_read, &items_written);
      |                                        ^~~
      |                                        |
      |                                        char *
bplist.c:1145:61: note: expected ‘const unsigned char *’ but argument is of type ‘char *’
 1145 | static uint16_t *plist_utf8_to_utf16be(const unsigned char *unistr, size_t size, size_t *items_read, size_t *items_written)
      |         
```

After fix:

There is no warning in compile process.