### PR TITLE
Fix issue #294, convert entlen to long int to avoid heap buffer overf…

### DIFF
--- a/src/xplist.c
+++ b/src/xplist.c
@@ -854,7 +854,7 @@ static int unescape_entities(char *str, size_t *length)
                 return -1;
             }
             if (str+i >= entp+1) {
-                int entlen = str+i - entp;
+                long int entlen = str+i - entp;
                 int bytelen = 1;
                 if (!strncmp(entp, "amp", 3)) {
                     /* the '&' is already there */


### PR DESCRIPTION
Fix https://github.com/libimobiledevice/libplist/issues/294, convert entlen to long int to avoid heap buffer overflow.

Before fix:

```
./tools/plistutil -i ./test++/14.plist 
=================================================================
==2067388==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7f4ccf3fb805 at pc 0x7f4d533b1397 bp 0x7ffe4aac0380 sp 0x7ffe4aabfb28
READ of size 4294967297 at 0x7f4ccf3fb805 thread T0
    #0 0x7f4d533b1396 in __interceptor_memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:827
    #1 0x55fcd77c7bd1 in byte_array_append /data/ylwang/Projects/libplist/src/bytearray.c:80
    #2 0x55fcd77aa80a in write_raw_data /data/ylwang/Projects/libplist/src/bplist.c:1094
    #3 0x55fcd77aa8c5 in write_string /data/ylwang/Projects/libplist/src/bplist.c:1104
    #4 0x55fcd77acb10 in plist_to_bin /data/ylwang/Projects/libplist/src/bplist.c:1429
    #5 0x55fcd77986e8 in main /data/ylwang/Projects/libplist/tools/plistutil.c:305
    #6 0x7f4d52a5bd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #7 0x7f4d52a5be3f in __libc_start_main_impl ../csu/libc-start.c:392
    #8 0x55fcd7796974 in _start (/data/ylwang/Projects/libplist/tools/plistutil+0x16974)

0x7f4ccf3fb805 is located 0 bytes to the right of 2147483653-byte region [0x7f4c4f3fb800,0x7f4ccf3fb805)
allocated by thread T0 here:
    #0 0x7f4d5342b887 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x55fcd779ebfc in text_parts_get_content /data/ylwang/Projects/libplist/src/xplist.c:935
    #2 0x55fcd77a19c2 in node_from_xml /data/ylwang/Projects/libplist/src/xplist.c:1258
    #3 0x55fcd77a38c4 in plist_from_xml /data/ylwang/Projects/libplist/src/xplist.c:1494
    #4 0x55fcd779860e in main /data/ylwang/Projects/libplist/tools/plistutil.c:300
    #5 0x7f4d52a5bd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: heap-buffer-overflow ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:827 in __interceptor_memcpy
Shadow bytes around the buggy address:
  0x0fea19e776b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fea19e776c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fea19e776d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fea19e776e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fea19e776f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0fea19e77700:[05]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0fea19e77710: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0fea19e77720: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0fea19e77730: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0fea19e77740: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0fea19e77750: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==2067388==ABORTING
```
After fix:

```
yuelinwang@XXF-GPU-03:/data/ylwang/Projects/libplist/tools$ ./plistutil -i ../test++/14.plist 
bplist00�WexampleQ>
```