### PR TITLE
Add OpenStep to man page

### DIFF
--- a/docs/plistutil.1
+++ b/docs/plistutil.1
@@ -1,13 +1,13 @@
 .TH "plistutil" 1
 .SH NAME
-plistutil \- Convert a plist FILE between binary, XML, and JSON format
+plistutil \- Convert a plist FILE between binary, XML, JSON, and OpenStep formats
 .SH SYNOPSIS
 .B plistutil
 [OPTIONS]
 [-i FILE]
 [-o FILE]
 .SH DESCRIPTION
-plistutil allows converting a Property List file between binary, XML, and JSON format.
+plistutil allows converting a Property List file between binary, XML, JSON, and OpenStep formats.
 .SH OPTIONS
 .TP
 .B \-i, \-\-infile FILE


### PR DESCRIPTION
When JSON support was added it was included in the name section of the man page:
https://github.com/libimobiledevice/libplist/commit/429cbc660ae14d4998715803b44c71abf0e4a339#diff-7473d26b110a32ac965591a19d4a286619fad708a1081808490b1ccd403970fdL3-L13

But when OpenStep support was added not all of the man page was updated:
https://github.com/libimobiledevice/libplist/commit/60d291941fadb72b66d11502710add5899e21a2d